### PR TITLE
`DeviceType` and `DeviceState` wiring

### DIFF
--- a/netrs-core/src/dbus.rs
+++ b/netrs-core/src/dbus.rs
@@ -56,8 +56,10 @@ impl NetworkManager {
                 .await?;
 
             let interface = d_proxy.interface().await?;
-            let device_type = d_proxy.device_type().await?;
-            let state = d_proxy.state().await?;
+            let raw_type = d_proxy.device_type().await?;
+            let device_type = raw_type.into();
+            let raw_state = d_proxy.state().await?;
+            let state = raw_state.into();
             let managed = d_proxy.managed().await.ok();
             let driver = d_proxy.driver().await.ok();
 

--- a/netrs-core/src/models.rs
+++ b/netrs-core/src/models.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
 use thiserror::Error;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -8,16 +9,34 @@ pub struct Network {
     pub secure: bool,
 }
 
-// Abstracting way the bus allows us to dump devices into the UI
-// without worrying about OwnedObjectPath, zbus::Connection, D-Bus errors, etc.
 #[derive(Debug, Clone)]
 pub struct Device {
     pub path: String,
     pub interface: String,
-    pub device_type: u32,
-    pub state: u32,
+    pub device_type: DeviceType,
+    pub state: DeviceState,
     pub managed: Option<bool>,
     pub driver: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub enum DeviceType {
+    Ethernet,
+    Wifi,
+    WifiP2P,
+    Loopback,
+    Other(u32),
+}
+
+#[derive(Debug, Clone)]
+pub enum DeviceState {
+    Unmanaged,
+    Unavailable,
+    Disconnected,
+    Prepare,
+    Config,
+    Activated,
+    Other(u32),
 }
 
 #[derive(Debug, Error)]
@@ -28,4 +47,56 @@ pub enum ConnectionError {
     NotFound,
     #[error("Authentication failed")]
     AuthFailed,
+}
+
+impl From<u32> for DeviceType {
+    fn from(value: u32) -> Self {
+        match value {
+            1 => DeviceType::Ethernet,
+            2 => DeviceType::Wifi,
+            30 => DeviceType::WifiP2P,
+            32 => DeviceType::Loopback,
+            v => DeviceType::Other(v),
+        }
+    }
+}
+
+impl From<u32> for DeviceState {
+    fn from(value: u32) -> Self {
+        match value {
+            10 => DeviceState::Unmanaged,
+            20 => DeviceState::Unavailable,
+            30 => DeviceState::Disconnected,
+            40 => DeviceState::Prepare,
+            50 => DeviceState::Config,
+            100 => DeviceState::Activated,
+            v => DeviceState::Other(v),
+        }
+    }
+}
+
+impl Display for DeviceType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DeviceType::Ethernet => write!(f, "Ethernet"),
+            DeviceType::Wifi => write!(f, "Wi-Fi"),
+            DeviceType::WifiP2P => write!(f, "Wi-Fi P2P"),
+            DeviceType::Loopback => write!(f, "Loopback"),
+            DeviceType::Other(v) => write!(f, "Other({})", v),
+        }
+    }
+}
+
+impl Display for DeviceState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DeviceState::Unmanaged => write!(f, "Unmanaged"),
+            DeviceState::Unavailable => write!(f, "Unavailable"),
+            DeviceState::Disconnected => write!(f, "Disconnected"),
+            DeviceState::Prepare => write!(f, "Preparing"),
+            DeviceState::Config => write!(f, "Configuring"),
+            DeviceState::Activated => write!(f, "Activated"),
+            DeviceState::Other(v) => write!(f, "Other({})", v),
+        }
+    }
 }

--- a/netrs-ui/src/main.rs
+++ b/netrs-ui/src/main.rs
@@ -45,7 +45,13 @@ async fn main() -> Result<(), ConnectionError> {
                 match nm2.list_devices().await {
                     Ok(devs) => {
                         for d in devs {
-                            eprintln!("Device: {:?}", d);
+                            eprintln!(
+                                "{} ({}) - {} [driver: {}]",
+                                d.interface,
+                                d.device_type,
+                                d.state,
+                                d.driver.as_deref().unwrap_or("unknown")
+                            );
                         }
                     }
                     Err(e) => eprintln!("Error: {:?}", e),


### PR DESCRIPTION
**Add basic NetworkManager device listing**

* Added `DeviceType` and `DeviceState` enums for common values (Ethernet, Wi-Fi, Loopback, etc.) with `Other(u32)` fallback
* Converted raw D-Bus `u32` properties into enums at the boundary
* Display devices in readable format: `<interface> (<type>) - <state> [driver: <driver>]`
