### PR TITLE
Implement `ListNetworks` and wire list into UI

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,10 +1,6 @@
 language: en-US
 tone_instructions: >
-  Idiomatic Rust suggestions only if they improve correctness, safety, or readability 
-  If no meaningful issues, respond “LGTM” 
-  Mark subjective feedback as non-blocking (nit) 
-  Do not use emojis, ascii art, or unrelated content 
-  Limit scope to netrs PRs
+  Idiomatic Rust suggestions only if they improve correctness, safety, or readability If no meaningful issues, respond “LGTM”Mark subjective feedback as non-blocking (nit) Do not use emojis, ascii art, or unrelated content Limit scope to netrs PRs
 
 reviews:
   profile: chill           

--- a/netrs-core/src/models.rs
+++ b/netrs-core/src/models.rs
@@ -2,11 +2,12 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use thiserror::Error;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Network {
+    pub device: String,
     pub ssid: String,
-    pub strength: u8,
-    pub secure: bool,
+    pub bssid: Option<String>,
+    pub strength: Option<u8>,
 }
 
 #[derive(Debug, Clone)]

--- a/netrs-ui/src/ui/mod.rs
+++ b/netrs-ui/src/ui/mod.rs
@@ -1,1 +1,27 @@
 pub mod header;
+pub mod networks;
+
+use gtk::prelude::*;
+use gtk::{Application, ApplicationWindow, Box, Label, Orientation, ScrolledWindow};
+use netrs_core::models::Network;
+
+pub fn build_ui(app: &Application, networks: Vec<Network>) {
+    let win = ApplicationWindow::new(app);
+    win.set_title(Some("netrs"));
+    win.set_default_size(400, 600);
+
+    let vbox = Box::new(Orientation::Vertical, 0);
+
+    let status = Label::new(None);
+    let header = header::build_header(&status);
+    vbox.append(&header);
+
+    let list = networks::networks_view(&networks);
+    let scroller = ScrolledWindow::new();
+    scroller.set_vexpand(true);
+    scroller.set_child(Some(&list));
+    vbox.append(&scroller);
+
+    win.set_child(Some(&vbox));
+    win.show();
+}

--- a/netrs-ui/src/ui/networks.rs
+++ b/netrs-ui/src/ui/networks.rs
@@ -1,0 +1,25 @@
+use gtk::prelude::*;
+use gtk::{Box, Label, ListBox, ListBoxRow, Orientation};
+use netrs_core::models;
+
+pub fn networks_view(networks: &[models::Network]) -> ListBox {
+    let list = ListBox::new();
+
+    for net in networks {
+        let row = ListBoxRow::new();
+        let hbox = Box::new(Orientation::Horizontal, 6);
+
+        let ssid = Label::new(Some(&net.ssid));
+
+        hbox.append(&ssid);
+        if let Some(s) = net.strength {
+            let strength_label = Label::new(Some(&format!("{s}%")));
+            hbox.append(&strength_label);
+        }
+
+        row.set_child(Some(&hbox));
+        list.append(&row);
+    }
+
+    list
+}


### PR DESCRIPTION
- Implements `ListNetwork`, defines new proxies for network scans and access points, and wires list of available networks into UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scans and lists available Wi‑Fi networks via NetworkManager.
  * Displays SSID, optional BSSID, and optional signal strength percentage.
  * Preloads networks on app launch for faster initial display.
  * Adds a reusable networks list view for scrolling display.

* **Refactor**
  * Centralized UI construction into a dedicated builder for cleaner startup flow.
  * Streamlined initialization and data loading.
  * Network model extended with device info and made clonable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->