### PR TITLE
Network scanning and `wifi_switch` implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,8 +788,10 @@ dependencies = [
 name = "netrs-core"
 version = "0.1.0"
 dependencies = [
+ "async-io",
  "serde",
  "thiserror",
+ "tokio",
  "tracing",
  "zbus",
  "zvariant",

--- a/netrs-core/Cargo.toml
+++ b/netrs-core/Cargo.toml
@@ -9,3 +9,5 @@ zvariant = "5.7.0"
 serde = { version = "1", features = ["derive"] }
 thiserror = "2.0.16"
 tracing = "0.1.41"
+tokio = "1.47.1"
+async-io = "2.6.0"

--- a/netrs-core/src/models.rs
+++ b/netrs-core/src/models.rs
@@ -20,7 +20,7 @@ pub struct Device {
     pub driver: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum DeviceType {
     Ethernet,
     Wifi,
@@ -29,7 +29,7 @@ pub enum DeviceType {
     Other(u32),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum DeviceState {
     Unmanaged,
     Unavailable,

--- a/netrs-ui/src/main.rs
+++ b/netrs-ui/src/main.rs
@@ -1,27 +1,21 @@
 use gtk::Application;
 use gtk::prelude::*;
-use netrs_core::{NetworkManager, models::ConnectionError};
-use std::sync::Arc;
 
 mod style;
 mod ui;
 
 use crate::style::load_css;
 
-#[tokio::main]
-async fn main() -> Result<(), ConnectionError> {
-    let nm = Arc::new(NetworkManager::new().await?);
-    let networks = nm.list_networks().await?;
-
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let app = Application::builder()
         .application_id("org.netrs.ui")
         .build();
 
     app.connect_activate(move |app| {
         load_css();
-        ui::build_ui(app, networks.clone());
+        ui::build_ui(app);
     });
 
     app.run();
-    Ok(())
 }

--- a/netrs-ui/src/style.css
+++ b/netrs-ui/src/style.css
@@ -1,25 +1,25 @@
-/* Dark global background */
+/* Global dark background */
 window {
-    background-color: #1e1e1e;
+    background-color: #121212;  /* deeper dark */
     color: #e0e0e0;
 }
 
 /* Header bar */
 headerbar {
-    background: #2a2a2a;
+    background: #1e1e1e;
     color: #e0e0e0;
-    border-bottom: 1px solid #3a3a3a;
+    border-bottom: 1px solid #2c2c2c;
 }
 
-/* Switch */
+/* Switch (toggle) */
 switch {
-    background-color: #3a3a3a;
+    background-color: #2a2a2a;
     border-radius: 12px;
     padding: 2px;
 }
 
 switch slider {
-    background-color: #e0e0e0;
+    background-color: #bbbbbb;
     border-radius: 10px;
 }
 
@@ -30,4 +30,50 @@ switch:checked {
 
 switch:checked slider {
     background-color: #ffffff;
+}
+
+/* Network selection rows */
+.network-selection {
+    padding: 8px 12px;
+    border-radius: 8px;
+    margin: 4px;
+    background: #1e1e1e;  
+    border: 1px solid #2c2c2c;
+}
+
+.network-selection label {
+    font-size: 14px;
+    color: #e0e0e0;
+}
+
+/* Hover effect */
+.network-selection:hover {
+    background: #2a2a2a;
+    border-color: #3a3a3a;
+    transition: background 150ms ease, border-color 150ms ease;
+}
+
+/* Selected row */
+.network-selection:selected {
+    background: #3a7bd5;
+    color: #ffffff;
+}
+
+/* ListBox container */
+list {
+    background: #121212;
+    border: none;
+}
+
+/* Individual rows */
+list > row {
+    background: transparent;
+    border: none;
+    padding: 0;
+}
+
+/* Row when selected */
+list > row:selected {
+    background: #3a7bd5;
+    color: #ffffff;
 }

--- a/netrs-ui/src/style.rs
+++ b/netrs-ui/src/style.rs
@@ -5,7 +5,6 @@ use gtk::gdk::Display;
 pub fn load_css() {
     let provider = CssProvider::new();
 
-    // Convert bytes to string literal
     let css = include_str!("style.css");
     provider.load_from_data(css);
 

--- a/netrs-ui/src/ui/header.rs
+++ b/netrs-ui/src/ui/header.rs
@@ -1,7 +1,11 @@
+use glib::timeout_future_seconds;
 use gtk::prelude::*;
-use gtk::{Box as GtkBox, HeaderBar, Label, Orientation, Switch};
+use gtk::{Align, Box as GtkBox, HeaderBar, Label, ListBox, Orientation, Switch};
+use netrs_core::NetworkManager;
 
-pub fn build_header(status: &Label) -> HeaderBar {
+use crate::ui::networks;
+
+pub fn build_header(status: &Label, list_container: &GtkBox) -> HeaderBar {
     let header = HeaderBar::new();
 
     let wifi_box = GtkBox::new(Orientation::Horizontal, 6);
@@ -11,15 +15,110 @@ pub fn build_header(status: &Label) -> HeaderBar {
     wifi_box.append(&wifi_label);
     wifi_box.append(&wifi_switch);
 
-    let status_clone = status.clone();
-    wifi_switch.connect_active_notify(move |sw| {
-        if sw.is_active() {
-            status_clone.set_text("");
-        } else {
-            status_clone.set_text("Wi-Fi is disabled");
-        }
-    });
+    {
+        let list_container_clone = list_container.clone();
+        let status_clone = status.clone();
+        let wifi_switch_clone = wifi_switch.clone();
+
+        glib::MainContext::default().spawn_local(async move {
+            clear_children(&list_container_clone);
+
+            match NetworkManager::new().await {
+                Ok(nm) => match nm.wifi_enabled().await {
+                    Ok(enabled) => {
+                        wifi_switch_clone.set_active(enabled);
+
+                        if enabled {
+                            status_clone.set_text("");
+                            match nm.list_networks().await {
+                                Ok(nets) => {
+                                    let list: ListBox = networks::networks_view(&nets);
+                                    list_container_clone.append(&list);
+                                }
+                                Err(err) => {
+                                    status_clone
+                                        .set_text(&format!("Error fetching networks: {err}"));
+                                }
+                            }
+                        } else {
+                            let disabled_label = Label::new(Some("Wi-Fi is disabled"));
+                            disabled_label.set_halign(Align::Center);
+                            disabled_label.set_valign(Align::Center);
+                            list_container_clone.append(&disabled_label);
+                        }
+                    }
+                    Err(err) => status_clone.set_text(&format!("Error: {err}")),
+                },
+                Err(err) => status_clone.set_text(&format!("Error: {err}")),
+            }
+        });
+    }
+
+    {
+        let list_container = list_container.clone();
+        let status_clone = status.clone();
+
+        wifi_switch.connect_active_notify(move |sw| {
+            let list_container = list_container.clone();
+            let status_clone = status_clone.clone();
+            let sw = sw.clone();
+
+            glib::MainContext::default().spawn_local(async move {
+                clear_children(&list_container);
+
+                match NetworkManager::new().await {
+                    Ok(nm) => {
+                        if let Err(err) = nm.set_wifi_enabled(sw.is_active()).await {
+                            status_clone.set_text(&format!("Error setting Wi-Fi: {err}"));
+                            return;
+                        }
+
+                        if sw.is_active() {
+                            status_clone.set_text("Enabling...");
+
+                            if nm.wait_for_wifi_ready().await.is_ok() {
+                                if let Err(err) = nm.scan_networks().await {
+                                    status_clone.set_text(&format!("Error scanning: {err}"));
+                                }
+
+                                timeout_future_seconds(2).await;
+
+                                match nm.list_networks().await {
+                                    Ok(nets) => {
+                                        status_clone.set_text("");
+                                        let list: ListBox = networks::networks_view(&nets);
+                                        list_container.append(&list);
+                                    }
+                                    Err(err) => {
+                                        status_clone
+                                            .set_text(&format!("Error fetching networks: {err}"));
+                                    }
+                                }
+                            } else {
+                                status_clone.set_text("Wi-Fi failed to initialize");
+                            }
+                        } else {
+                            status_clone.set_text("Wi-Fi is disabled");
+                            let disabled_label = Label::new(Some("Wi-Fi is disabled"));
+                            disabled_label.set_halign(Align::Center);
+                            disabled_label.set_valign(Align::Center);
+                            list_container.append(&disabled_label);
+                        }
+                    }
+                    Err(err) => status_clone.set_text(&format!("Error: {err}")),
+                }
+            });
+        });
+    }
 
     header.pack_start(&wifi_box);
     header
+}
+
+fn clear_children(container: &gtk::Box) {
+    let mut child = container.first_child();
+    while let Some(widget) = child {
+        child = widget.next_sibling();
+        container.remove(&widget);
+    }
 }

--- a/netrs-ui/src/ui/mod.rs
+++ b/netrs-ui/src/ui/mod.rs
@@ -2,24 +2,25 @@ pub mod header;
 pub mod networks;
 
 use gtk::prelude::*;
-use gtk::{Application, ApplicationWindow, Box, Label, Orientation, ScrolledWindow};
-use netrs_core::models::Network;
+use gtk::{Application, ApplicationWindow, Box as GtkBox, Label, Orientation, ScrolledWindow};
 
-pub fn build_ui(app: &Application, networks: Vec<Network>) {
+pub fn build_ui(app: &Application) {
     let win = ApplicationWindow::new(app);
     win.set_title(Some("netrs"));
     win.set_default_size(400, 600);
 
-    let vbox = Box::new(Orientation::Vertical, 0);
+    let vbox = GtkBox::new(Orientation::Vertical, 0);
 
     let status = Label::new(None);
-    let header = header::build_header(&status);
+
+    let list_container = GtkBox::new(Orientation::Vertical, 0);
+
+    let header = header::build_header(&status, &list_container);
     vbox.append(&header);
 
-    let list = networks::networks_view(&networks);
     let scroller = ScrolledWindow::new();
     scroller.set_vexpand(true);
-    scroller.set_child(Some(&list));
+    scroller.set_child(Some(&list_container));
     vbox.append(&scroller);
 
     win.set_child(Some(&vbox));

--- a/netrs-ui/src/ui/networks.rs
+++ b/netrs-ui/src/ui/networks.rs
@@ -9,6 +9,7 @@ pub fn networks_view(networks: &[models::Network]) -> ListBox {
         let row = ListBoxRow::new();
         let hbox = Box::new(Orientation::Horizontal, 6);
 
+        row.add_css_class("network-selection");
         let ssid = Label::new(Some(&net.ssid));
 
         hbox.append(&ssid);


### PR DESCRIPTION
* Added async methods to `NetworkManager` for checking, enabling/disabling Wi-Fi, waiting for Wi-Fi readiness, and scanning for networks, enabling dynamic control of Wi-Fi state from the UI.
* Updated the `NM` trait to expose `wireless_enabled` and `set_wireless_enabled` properties for D-Bus communication.
* Improved SSID handling to display "<Hidden Network>" for networks with missing or invalid SSIDs.

- Also messed around with the UI to clean up the layout and work cleanly with the current goal
 ----
The current approach to scanning and populating wifi networks depends on waiting and rescanning after toggling the `wifi_switch` which is unreliable because device initialization time is nondeterministic and access points may not be available when we poll. 

The correct implementation is to subscribe to NetworkManager’s D-Bus signals (`Device.StateChanged`, `AccessPointAdded/Removed`) so the UI updates reactively when the radio is ready and networks appear, eliminating arbitrary sleeps and ensuring consistent synchronization with the daemon’s actual state.
