### PR TITLE
network label: connection signal colors

### DIFF
--- a/netrs-ui/src/style.css
+++ b/netrs-ui/src/style.css
@@ -67,8 +67,12 @@ switch:checked slider {
   color: white;
 }
 
-label.network-okay {
+label.network-good {
   color: green;
+}
+
+label.network-okay {
+  color: orange;
 }
 
 label.network-poor {

--- a/netrs-ui/src/ui/networks.rs
+++ b/netrs-ui/src/ui/networks.rs
@@ -34,6 +34,8 @@ pub fn networks_view(networks: &[models::Network]) -> ListBox {
             hbox.append(&strength_label);
 
             if s >= conn_threshold {
+                strength_label.add_css_class("network-good");
+            } else if s > 65 {
                 strength_label.add_css_class("network-okay");
             } else {
                 strength_label.add_css_class("network-poor");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced a distinct “Good” network status with green styling, shown for strong signal strength to provide clearer positive feedback.

* Style
  * Updated network status colors and classes: “Okay” now displays in orange, “Good” in green, and “Poor” remains unchanged. This clarifies visual differentiation between Good, Okay, and Poor states across the UI and improves consistency in network strength indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->