### PR TITLE
pwd input handling, conditional logic on open networks, and sec refactor

### DIFF
--- a/netrs-core/src/dbus.rs
+++ b/netrs-core/src/dbus.rs
@@ -1,4 +1,5 @@
 use crate::models::{Device, DeviceState, DeviceType, Network};
+use std::arch::x86_64::_pdep_u32;
 use std::collections::HashMap;
 use std::time::Duration;
 use uuid::Uuid;
@@ -245,14 +246,17 @@ impl NetworkManager {
             s_wifi.insert("ssid", Value::from(ssid.as_bytes().to_vec()));
             s_wifi.insert("mode", Value::from("infrastructure"));
 
-            let mut s_sec = HashMap::new();
-            s_sec.insert("key-mgmt", Value::from("wpa-psk"));
-            s_sec.insert("psk", Value::from(_password));
-
             let mut conn = HashMap::new();
             conn.insert("connection", s_conn);
             conn.insert("802-11-wireless", s_wifi);
-            conn.insert("802-11-wireless-security", s_sec);
+            
+            if !_password.is_empty() {
+                let mut s_sec = HashMap::new();
+                s_sec.insert("key-mgmt", Value::from("wpa-psk"));
+                s_sec.insert("psk", Value::from(_password));
+                conn.insert("802-11-wireless-security", s_sec);
+            }
+
             conn
         };
 

--- a/netrs-ui/src/style.css
+++ b/netrs-ui/src/style.css
@@ -98,17 +98,25 @@ list > row:selected {
     color: #ffffff;
 }
 
-dialog {
-    background-color: #2b2b2b;
-    border-radius: 8px;
-    margin: 16px;
+.modern-dialog {
+  border-radius: 12px;
+  background: #2b2b2b;
 }
 
-entry {
-    border-radius: 4px;
-    padding: 4px 8px;
+.dialog-label {
+  color: #e0e0e0;
+  font-size: 14px;
 }
 
-.diag-buttons {
-  padding-bottom: 12px;
+.password-entry {
+  border-radius: 8px;
+  padding: 6px 10px;
+  background: #3a3a3a;
+  color: #f5f5f5;
 }
+
+button {
+  border-radius: 8px;
+  padding: 6px 14px;
+}
+

--- a/netrs-ui/src/ui/connect.rs
+++ b/netrs-ui/src/ui/connect.rs
@@ -1,16 +1,16 @@
-use gtk::{ApplicationWindow, prelude::*};
-use gtk::{Box as GtkBox, Dialog, DialogFlags, Entry, Label, Orientation, ResponseType};
+use glib::Propagation;
+use gtk::{
+    ApplicationWindow, Box as GtkBox, Dialog, Entry, EventControllerKey, Label, Orientation,
+    prelude::*,
+};
+use netrs_core::NetworkManager;
+use std::rc::Rc;
 
-pub fn connect_modal(parent: &ApplicationWindow) {
-    let dialog = Dialog::with_buttons(
-        Some("Connect to Network"),
-        Some(parent),
-        DialogFlags::MODAL,
-        &[
-            ("Cancel", ResponseType::Cancel),
-            ("Connect", ResponseType::Accept),
-        ],
-    );
+pub fn connect_modal(parent: &ApplicationWindow, ssid: &str) {
+    let dialog = Dialog::new();
+    dialog.set_title(Some("Connect to Network"));
+    dialog.set_transient_for(Some(parent));
+    dialog.set_modal(true);
     dialog.add_css_class("diag-buttons");
 
     let content_area = dialog.content_area();
@@ -23,21 +23,49 @@ pub fn connect_modal(parent: &ApplicationWindow) {
     let label = Label::new(Some("Enter network password:"));
     let entry = Entry::new();
     entry.set_placeholder_text(Some("Password"));
-    entry.set_visibility(false); // hides characters
+    entry.set_visibility(false);
 
     vbox.append(&label);
     vbox.append(&entry);
     content_area.append(&vbox);
-
-    dialog.set_default_response(ResponseType::Accept);
-    dialog.show();
-
-    dialog.connect_response(move |d, resp| {
-        if resp == ResponseType::Accept {
+    
+    let dialog_rc = Rc::new(dialog);
+    let ssid_owned = ssid.to_string();
+    {
+        let dialog_rc = dialog_rc.clone();
+        entry.connect_activate(move |entry| {
             let pwd = entry.text();
-            println!("User entered: {}", pwd);
-            // insert connection logic here
-        }
-        d.close();
-    });
+            println!("User entered: {pwd}");
+
+            let ssid = ssid_owned.clone();
+            glib::MainContext::default().spawn_local(async move {
+                match NetworkManager::new().await {
+                    Ok(nm) => {
+                        if let Err(err) = nm.connect(&ssid, &pwd).await {
+                            eprintln!("Failed to connect: {err}");
+                        }
+                    }
+                    Err(err) => eprintln!("Failed to init NetworkManager: {err}"),
+                }
+            });
+
+            dialog_rc.close();
+        });
+    }
+
+    {
+        let dialog_rc = dialog_rc.clone();
+        let key_controller = EventControllerKey::new();
+        key_controller.connect_key_pressed(move |_, key, _, _| {
+            if key == gtk::gdk::Key::Escape {
+                dialog_rc.close();
+                Propagation::Stop
+            } else {
+                Propagation::Proceed
+            }
+        });
+        entry.add_controller(key_controller);
+    }
+
+    dialog_rc.show();
 }


### PR DESCRIPTION
- Handle pwd input, removed buttons and conditionally skip prompt on open networks
- Refactor `dbus` proxy to conditionally build map connection 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Security configuration now only applied when a password is provided

* **New Features**
  * Double-click networks to connect (secured networks prompt for password, unsecured networks connect automatically)
  * Escape key closes the connection dialog

* **Style**
  * Updated dialog and password entry styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->