### PR TITLE
Revert changes to simplified `build_wifi_connection` to preserve base connection logic

### DIFF
--- a/nmrs-core/src/dbus.rs
+++ b/nmrs-core/src/dbus.rs
@@ -59,7 +59,7 @@ pub trait NM {
         specific_object: OwnedObjectPath,
     ) -> zbus::Result<(OwnedObjectPath, OwnedObjectPath)>;
 
-    fn deactivate_connection(&self, active_connetion: OwnedObjectPath) -> zbus::Result<()>;
+    fn deactivate_connection(&self, active_connection: OwnedObjectPath) -> zbus::Result<()>;
 }
 
 #[proxy(
@@ -336,7 +336,6 @@ impl NetworkManager {
 
     pub async fn wait_for_wifi_ready(&self) -> Result<()> {
         for _ in 0..20 {
-            // FIXME: longer? shorter? is this even where the issue is?
             let devices = self.list_devices().await?;
             for dev in devices {
                 if dev.device_type == DeviceType::Wifi

--- a/nmrs-core/src/wifi_builders.rs
+++ b/nmrs-core/src/wifi_builders.rs
@@ -3,7 +3,7 @@ use zvariant::Value;
 
 use crate::models;
 
-fn bytes(val: &str) -> Vec<u8> {
+/*fn bytes(val: &str) -> Vec<u8> {
     val.as_bytes().to_vec()
 }
 
@@ -104,5 +104,36 @@ pub fn build_wifi_connection(
             conn.insert("802-1x", e1x);
         }
     }
+    conn
+}*/
+
+pub fn build_wifi_connection(
+    ssid: &str,
+    security: &models::WifiSecurity,
+) -> HashMap<&'static str, HashMap<&'static str, zvariant::Value<'static>>> {
+    let mut conn = HashMap::new();
+
+    let mut s_conn = HashMap::new();
+    s_conn.insert("type", Value::from("802-11-wireless"));
+    s_conn.insert("id", Value::from(ssid.to_string()));
+    s_conn.insert("uuid", Value::from(uuid::Uuid::new_v4().to_string()));
+    conn.insert("connection", s_conn);
+
+    let mut s_wifi = HashMap::new();
+    s_wifi.insert("ssid", Value::from(ssid.as_bytes().to_vec()));
+    s_wifi.insert("mode", Value::from("infrastructure"));
+    conn.insert("802-11-wireless", s_wifi);
+
+    match security {
+        models::WifiSecurity::Open => {}
+        models::WifiSecurity::WpaPsk { psk } => {
+            let mut s_sec = HashMap::new();
+            s_sec.insert("key-mgmt", Value::from("wpa-psk"));
+            s_sec.insert("psk", Value::from(psk.to_string()));
+            conn.insert("802-11-wireless-security", s_sec);
+        }
+        _ => {}
+    }
+
     conn
 }

--- a/nmrs-ui/src/ui/networks.rs
+++ b/nmrs-ui/src/ui/networks.rs
@@ -61,7 +61,6 @@ pub fn networks_view(
         arrow.add_css_class("network-arrow");
         hbox.append(&arrow);
 
-        // debouncing is not needed here unless we add logic for single clicks
         let ssid_str = net.ssid.clone();
         let secured = net.secured;
         let is_eap = net.is_eap;


### PR DESCRIPTION
### `build_wifi_connection` simplification
The previous implementation added layered builders (`wifi_builders.rs`) that explicitly set NetworkManager D-Bus fields for WPA-EAP and other security types. 

These extra keys caused schema mismatches such as `InvalidProperty: 802-11-wireless-security.key-mgmt`, breaking normal WPA-PSK connections.  

The revert restores the minimal connection schema that relies on NetworkManager’s own defaults, which proved stable and functional. Advanced EAP handling will be re-implemented later following the official D-Bus and nm-setting-802-1x specifications.

See #32