### PR TITLE
Dbus API mismatches,

### DIFF
--- a/nmrs-core/src/models.rs
+++ b/nmrs-core/src/models.rs
@@ -8,6 +8,7 @@ pub struct Network {
     pub ssid: String,
     pub bssid: Option<String>,
     pub strength: Option<u8>,
+    pub frequency: Option<u32>,
     pub secured: bool,
     pub is_psk: bool,
     pub is_eap: bool,
@@ -56,6 +57,12 @@ pub struct EapOptions {
     pub system_ca_certs: bool,
     pub method: EapMethod,
     pub phase2: Phase2,
+}
+
+pub struct ConnectionOptions {
+    pub autoconnect: bool,
+    pub autoconnect_priority: Option<i32>,
+    pub autoconnect_retries: Option<i32>,
 }
 
 pub enum WifiSecurity {

--- a/nmrs-core/tests/wifi_buillders_test.rs
+++ b/nmrs-core/tests/wifi_buillders_test.rs
@@ -1,10 +1,18 @@
-use nmrs_core::models::WifiSecurity;
+use nmrs_core::models::{ConnectionOptions, WifiSecurity};
 use nmrs_core::wifi_builders::build_wifi_connection;
 use zvariant::Value;
 
+fn opts() -> ConnectionOptions {
+    ConnectionOptions {
+        autoconnect: true,
+        autoconnect_priority: None,
+        autoconnect_retries: None,
+    }
+}
+
 #[test]
 fn builds_open_wifi_connection() {
-    let conn = build_wifi_connection("testnet", &WifiSecurity::Open);
+    let conn = build_wifi_connection("testnet", &WifiSecurity::Open, &opts());
     assert!(conn.contains_key("connection"));
     assert!(conn.contains_key("802-11-wireless"));
     assert!(conn.contains_key("ipv4"));
@@ -18,6 +26,7 @@ fn builds_psk_wifi_connection_with_security_section() {
         &WifiSecurity::WpaPsk {
             psk: "pw123".into(),
         },
+        &opts(),
     );
     let has_sec = conn.contains_key("802-11-wireless-security");
     assert!(has_sec, "security section missing");

--- a/nmrs-ui/src/ui/header.rs
+++ b/nmrs-ui/src/ui/header.rs
@@ -1,15 +1,6 @@
-use futures_util::StreamExt;
-use glib::ControlFlow;
 use gtk::prelude::*;
 use gtk::{Box as GtkBox, HeaderBar, Label, ListBox, Orientation, Switch};
 use nmrs_core::NetworkManager;
-use nmrs_core::dbus::{NMProxy, NMWirelessProxy};
-use std::cell::Cell;
-use zbus::Connection;
-
-thread_local! {
-    static REFRESH_SCHEDULED: Cell<bool> = const { Cell::new(false) };
-}
 
 use crate::ui::networks;
 
@@ -60,9 +51,10 @@ pub fn build_header(
                         if enabled {
                             status_clone.set_text("Scanning...");
                             let _ = nm.scan_networks().await;
-                            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                            glib::timeout_future_seconds(2).await;
                             match nm.list_networks().await {
                                 Ok(nets) => {
+                                    status_clone.set_text("");
                                     let list: ListBox =
                                         networks::networks_view(&nets, &pw, &stack_clone);
                                     list_container_clone.append(&list);
@@ -107,14 +99,7 @@ pub fn build_header(
                             if nm.wait_for_wifi_ready().await.is_ok() {
                                 let _ = nm.scan_networks().await;
                                 status_clone.set_text("Scanning...");
-
-                                spawn_signal_listeners(
-                                    list_container_clone.clone(),
-                                    status_clone.clone(),
-                                    &pw,
-                                    &stack_inner,
-                                )
-                                .await;
+                                glib::timeout_future_seconds(2).await;
 
                                 match nm.list_networks().await {
                                     Ok(nets) => {
@@ -149,132 +134,4 @@ fn clear_children(container: &gtk::Box) {
         child = widget.next_sibling();
         container.remove(&widget);
     }
-}
-
-async fn spawn_signal_listeners(
-    list_container: GtkBox,
-    status: Label,
-    parent_window: &gtk::ApplicationWindow,
-    stack: &gtk::Stack,
-) {
-    let conn = match Connection::system().await {
-        Ok(c) => c,
-        Err(e) => {
-            status.set_text(&format!("DBus conn error: {e}"));
-            return;
-        }
-    };
-
-    let nm_proxy = match NMProxy::new(&conn).await {
-        Ok(p) => p,
-        Err(e) => {
-            status.set_text(&format!("NM proxy error: {e}"));
-            return;
-        }
-    };
-
-    let devices = match nm_proxy.get_devices().await {
-        Ok(d) => d,
-        Err(e) => {
-            status.set_text(&format!("Get devices error: {e}"));
-            return;
-        }
-    };
-
-    for dev_path in devices {
-        let builder = match NMWirelessProxy::builder(&conn).path(dev_path.clone()) {
-            Ok(b) => b,
-            Err(_) => continue,
-        };
-
-        let wifi = match builder.build().await {
-            Ok(proxy) => proxy,
-            Err(_) => continue,
-        };
-
-        let mut added = match wifi.receive_access_point_added().await {
-            Ok(s) => s,
-            Err(_) => continue,
-        };
-        let mut removed = match wifi.receive_access_point_removed().await {
-            Ok(s) => s,
-            Err(_) => continue,
-        };
-
-        let list_container_signal = list_container.clone();
-        let status_signal = status.clone();
-        let pw = parent_window.clone();
-        let stack_signal = stack.clone();
-
-        glib::MainContext::default().spawn_local(async move {
-            loop {
-                tokio::select! {
-                    event = added.next() => match event {
-                        Some(_) => {
-                            schedule_refresh(list_container_signal.clone(), status_signal.clone(), &pw, &stack_signal).await;
-                        }
-                        None => break,
-                    },
-                    event = removed.next() => match event {
-                        Some(_) => {
-                            schedule_refresh(list_container_signal.clone(), status_signal.clone(), &pw, &stack_signal).await;
-                        }
-                        None => break,
-                    },
-                }
-            }
-        });
-    }
-}
-
-async fn refresh_networks(
-    list_container: &GtkBox,
-    status: &Label,
-    parent_window: &gtk::ApplicationWindow,
-    stack: &gtk::Stack,
-) {
-    match NetworkManager::new().await {
-        Ok(nm) => match nm.list_networks().await {
-            Ok(nets) => {
-                clear_children(list_container);
-                let list: ListBox = networks::networks_view(&nets, parent_window, stack);
-                list_container.append(&list);
-            }
-            Err(e) => status.set_text(&format!("Error refreshing networks: {e}")),
-        },
-        Err(e) => status.set_text(&format!("Error refreshing networks: {e}")),
-    }
-}
-
-async fn schedule_refresh(
-    list_container: GtkBox,
-    status: Label,
-    parent_window: &gtk::ApplicationWindow,
-    stack: &gtk::Stack,
-) {
-    REFRESH_SCHEDULED.with(|flag| {
-        if flag.get() {
-            return;
-        }
-        flag.set(true);
-
-        let list_container_clone = list_container.clone();
-        let status_clone = status.clone();
-        let pw = parent_window.clone();
-        let stack_clone = stack.clone();
-
-        glib::timeout_add_seconds_local(1, move || {
-            let list_container_inner = list_container_clone.clone();
-            let status_inner = status_clone.clone();
-            let pw2 = pw.clone();
-            let stack_inner = stack_clone.clone();
-
-            glib::MainContext::default().spawn_local(async move {
-                refresh_networks(&list_container_inner, &status_inner, &pw2, &stack_inner).await;
-                REFRESH_SCHEDULED.with(|f| f.set(false));
-            });
-
-            ControlFlow::Break
-        });
-    });
 }


### PR DESCRIPTION
## Changes

- Fixed WPA-PSK authentication by setting `psk-flags=0` to pass secrets during connection activation instead of requiring secret agent
- Added automatic detection and deletion of corrupted saved connections with retry logic using fresh settings
- Implemented network deduplication by (SSID, frequency) to separate 2.4GHz and 5GHz bands as distinct entries
- Added network list sorting by signal strength (descending) (this is still kinda shitty)
- Enhanced connection error reporting with detailed `NetworkManager` state reason codes
- Fixed connection settings to use proper D-Bus array signatures for proto/pairwise/group fields
- Reintroduced EAP settings for `wifi_builder`
- Added dedicated `delete_connection()` method that properly calls the D-Bus Delete method on connection settings, replacing the previous non-functional deletion logic in `forget()`
- Properly implemented/fixed saved connections inadvertently prompting for passwords again
  - Changed `get_saved_connection_path()` to return `Option<OwnedObjectPath> `instead of `boolean`, enabling direct connection deletion and activation by path reference