### PR TITLE
`refresh_networks` helper for proper scanning; adjusted polling …

### DIFF
--- a/nmrs-ui/src/ui/mod.rs
+++ b/nmrs-ui/src/ui/mod.rs
@@ -8,6 +8,8 @@ use gtk::{
     Application, ApplicationWindow, Box as GtkBox, Label, Orientation, ScrolledWindow, Spinner,
     Stack,
 };
+use std::cell::Cell;
+use std::rc::Rc;
 
 pub fn build_ui(app: &Application) {
     let win = ApplicationWindow::new(app);
@@ -17,8 +19,8 @@ pub fn build_ui(app: &Application) {
     let vbox = GtkBox::new(Orientation::Vertical, 0);
     let status = Label::new(None);
     let list_container = GtkBox::new(Orientation::Vertical, 0);
-
     let stack = Stack::new();
+    let is_scanning = Rc::new(Cell::new(false));
 
     let spinner = Spinner::new();
     spinner.set_halign(gtk::Align::Center);
@@ -33,7 +35,7 @@ pub fn build_ui(app: &Application) {
 
     stack.add_named(&list_container, Some("networks"));
 
-    let header = header::build_header(&status, &list_container, &win, &stack);
+    let header = header::build_header(&status, &list_container, &win, &stack, is_scanning);
     vbox.append(&header);
 
     let scroller = ScrolledWindow::new();


### PR DESCRIPTION
**Changes**
- Fixed race condition in both async blocks of `build_header` to instead grab network instance from new helper `refresh_networks`
- Wrapped scanning behavior in `Rc` to  ensure atomic access and prevent concurrent scan overlaps across async contexts, avoiding duplicate or out-of-order network list population during initialization.

This should fix issues where the incorrect order/amount of networks would show up upon launch of the program