### PR TITLE
feat(UI/Dbus proxy): UI and QOL fixes

### DIFF
--- a/nmrs-ui/src/style.css
+++ b/nmrs-ui/src/style.css
@@ -68,9 +68,24 @@ list > row:selected {
   border-color: #3a3a3a;
   transition: background 150ms ease, border-color 150ms ease;
 }
+.network-selection.connected {
+  background: rgba(34, 197, 94, 0.15);
+  border-color: rgba(34, 197, 94, 0.3);
+}
+.network-selection.connected:hover {
+  background: rgba(34, 197, 94, 0.2);
+  border-color: rgba(34, 197, 94, 0.4);
+}
 .network-selection label {
   font-size: 14px;
   color: #e0e0e0;
+}
+.connected-label {
+  font-size: 12px;
+  color: #22c55e;
+  font-style: italic;
+  margin-left: 8px;
+  opacity: 0.9;
 }
 
 label.network-good { color: #22c55e; }


### PR DESCRIPTION
### Changes made

- Deduplicate networks by SSID + frequency band to remove duplicate entries
- Add `current_connection_info()` method returning SSID and frequency of active connection
- Sort connected network to top of list
- Highlight connected network with green background and border
- Add "Connected" text label next to connected network name
- Match connected network by both SSID and frequency band (not just SSID)
- Show a wrong password message on authentication failures
- Move disconnection logic to occur only after network verification and right before connection attempt
- Detect connections stuck in Config state (50) as authentication failures (This needs some work)
- Return authentication error when connection times out in Config state instead of returning success