### PR TITLE
fix: nix run

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,19 @@
             '';
           };
 
-        packages.default = naersk-package.buildPackage ./.;
+        packages.default = naersk-package.buildPackage {
+          pname = "nmrs";
+          src = ./.;
+
+          buildInputs = with pkgs; [
+            pkg-config
+            wrapGAppsHook4
+            libxkbcommon
+            glib
+          ];
+
+          meta.mainProgram = "nmrs-ui";
+        };
       }
     );
 }


### PR DESCRIPTION
```bash
$ nix run github:cachebag/nmrs
error: Cannot build '/nix/store/z2gq6v3a9j8ig7qkvdy5pfx6fvpslx8h-rust-workspace-deps-unknown.drv'.
       Reason: builder failed with exit code 101.
       Output paths:
         /nix/store/0jgk3w698wwkrbjnmbsm5bcwk8fqbf24-rust-workspace-deps-unknown
       Last 25 log lines:
       >   cargo:rerun-if-env-changed=PKG_CONFIG_PATH
       >   cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
       >   cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
       >   cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
       >   cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
       >   cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
       >   cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
       >   cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
       >   cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
       >   cargo:warning=Could not run `PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --libs --cflags glib-2.0 'glib-2.0 >= 2.72'`
       >   The pkg-config command could not be found.
       >
       >   Most likely, you need to install a pkg-config package for your OS.
       >   Try `apt install pkg-config`, or `yum install pkg-config`, or `brew install pkgconf`
       >   or `pkg install pkg-config`, or `apk add pkgconfig` depending on your distribution.
       >
       >   If you've already installed it, ensure the pkg-config command is one of the
       >   directories in the PATH environment variable.
       >
       >   If you did not expect this build to link to a pre-installed system library,
       >   then check documentation of the glib-sys crate for an option to
       >   build the library from source, or disable features or dependencies
       >   that require pkg-config.
       > warning: build failed, waiting for other jobs to finish...
       > [naersk] cargo returned with exit code 101, exiting
       For full logs, run:
         nix log /nix/store/z2gq6v3a9j8ig7qkvdy5pfx6fvpslx8h-rust-workspace-deps-unknown.drv
error: Cannot build '/nix/store/xwd09nxnl0z8m0fpqc4kr2w5kyhib1kw-rust-workspace-unknown.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/yvcjrsgfxb72lxglv1xjnb0i9c0m2hs5-rust-workspace-unknown
```

looks to work fine after these changes