### PR TITLE
fix: seperate `ScrolledWindow` for each stack child

### DIFF
--- a/nmrs-ui/src/style.css
+++ b/nmrs-ui/src/style.css
@@ -36,23 +36,6 @@ window {
   color: var(--text-primary);
 }
 
-scrolledwindow {
-  overflow: hidden;
-}
-
-scrolledwindow > viewport {
-  background: inherit;
-}
-
-scrollbar,
-scrollbar slider,
-scrollbar trough {
-  background: transparent;
-  border: none;
-  min-width: 0;
-  min-height: 0;
-}
-
 headerbar {
   background: var(--bg-secondary);
   color: var(--text-primary);
@@ -61,16 +44,9 @@ headerbar {
 
 switch {
   background-color: var(--bg-tertiary);
-  padding: 2px;
-}
-switch slider {
-  background-color: var(--text-secondary);
 }
 switch:checked {
   background-color: var(--accent-color);
-}
-switch:checked slider {
-  background-color: var(--bg-primary);
 }
 
 .wifi-label {
@@ -138,8 +114,6 @@ label.network-poor { color: var(--error-color); }
   padding: 16px 20px;
   border: none;
   color: var(--text-primary);
-  min-height: 0;
-  max-height: none;
 }
 
 .back-button {

--- a/nmrs-ui/src/ui/mod.rs
+++ b/nmrs-ui/src/ui/mod.rs
@@ -19,7 +19,6 @@ pub fn build_ui(app: &Application) {
     win.set_title(Some(""));
     win.set_default_size(400, 600);
 
-    // Load and apply saved theme preference
     let is_light = crate::theme_config::load_theme();
     if is_light {
         win.add_css_class("light-theme");
@@ -43,8 +42,6 @@ pub fn build_ui(app: &Application) {
 
     stack.add_named(&spinner, Some("loading"));
     stack.set_visible_child_name("loading");
-
-    stack.add_named(&list_container, Some("networks"));
 
     let status_clone = status.clone();
     let list_container_clone = list_container.clone();
@@ -95,7 +92,6 @@ pub fn build_ui(app: &Application) {
                         });
                     }) as Rc<dyn Fn()>;
 
-                    // Store the callback in the cell for self-reference
                     *on_success_cell_clone.borrow_mut() = Some(callback.clone());
 
                     callback
@@ -119,12 +115,15 @@ pub fn build_ui(app: &Application) {
         }
     });
 
-    let scroller = ScrolledWindow::new();
-    scroller.set_vexpand(true);
-    scroller.set_policy(gtk::PolicyType::Never, gtk::PolicyType::Automatic);
-    scroller.set_propagate_natural_height(true);
-    scroller.set_child(Some(&stack));
-    vbox.append(&scroller);
+    let networks_scroller = ScrolledWindow::new();
+    networks_scroller.set_vexpand(true);
+    networks_scroller.set_policy(gtk::PolicyType::Never, gtk::PolicyType::Automatic);
+    networks_scroller.set_child(Some(&list_container));
+
+    stack.add_named(&networks_scroller, Some("networks"));
+
+    stack.set_vexpand(true);
+    vbox.append(&stack);
 
     win.set_child(Some(&vbox));
     win.show();

--- a/nmrs-ui/src/ui/networks.rs
+++ b/nmrs-ui/src/ui/networks.rs
@@ -185,7 +185,13 @@ pub fn networks_view(
     });
 
     let details_page = Rc::new(NetworkPage::new(&ctx.stack));
-    ctx.stack.add_named(details_page.widget(), Some("details"));
+
+    // Wrap the details page in its own ScrolledWindow
+    let details_scroller = gtk::ScrolledWindow::new();
+    details_scroller.set_policy(gtk::PolicyType::Never, gtk::PolicyType::Automatic);
+    details_scroller.set_child(Some(details_page.widget()));
+
+    ctx.stack.add_named(&details_scroller, Some("details"));
 
     for net in sorted_networks {
         let row = ListBoxRow::new();


### PR DESCRIPTION
fixes an issue we had where a long network list produced a lot of empty space when navigating to the network info page