### PR TITLE
chore: drop deps we arent using

### DIFF
--- a/nmrs-core/Cargo.toml
+++ b/nmrs-core/Cargo.toml
@@ -8,12 +8,8 @@ zbus = "5.11.0"
 zvariant = "5.7.0"
 serde = { version = "1", features = ["derive"] }
 thiserror = "2.0.16"
-tracing = "0.1.41"
-tokio = { version = "1.48.0", features = ["rt-multi-thread", "macros", "sync", "time"] }
-async-io = "2.6.0"
 futures-timer = "3.0.3"
-futures-util = "0.3.31"
-neli = "0.7.1"
-if-addrs = "0.14.0"
-ipnetwork = "0.21.1"
 uuid = { version = "1.18.1", features = ["v4"] }
+
+[dev-dependencies]
+tokio = { version = "1.48.0", features = ["rt-multi-thread", "macros", "sync", "time"] }

--- a/nmrs-ui/Cargo.toml
+++ b/nmrs-ui/Cargo.toml
@@ -8,11 +8,6 @@ nmrs-core = { path = "../nmrs-core" }
 tokio = { version = "1.47.1", features = ["full"] }
 gtk = { version = "0.10.1", package = "gtk4" }
 glib = "0.21.3"
-futures-util = "0.3.31"
-zbus = "5.11.0"
-smithay-client-toolkit = "0.20.0"
-calloop = "0.14.3"
-relm4 = "0.10.0"
 dirs = "6.0.0"
 fs2 = "0.4.3"
 anyhow = "1.0.100" 


### PR DESCRIPTION
dropping deps some of which are fairly heavy

(probabaly will use `smithay-client-toolkit` eventually)