### PR TITLE
release: nmrs-1.1.0 | nmrs-gui-1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ RELEASE_NOTES.md
 __pycache__/
 *.pyc
 vendor/
+/pkg/
+/src/
+*.pkg.tar.zst

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 ## [Unreleased]
-- Fixed native WireGuard profile structure ([#135](https://github.com/cachebag/nmrs/issues/135))
+### Fixed
+- Native WireGuard profile structure ([#135](https://github.com/cachebag/nmrs/issues/135))
+- Corrected binary name for `.desktop` file + `postInstall` hook for Nix flake ([#146](https://github.com/cachebag/nmrs/pull/146))
+
+### Added
+- Added WireGuard connection example to docs ([#137](https://github.com/cachebag/nmrs/pull/137))
+
+## [1.0.1] - 2025-12-15
+- Update docs for various structs, enums and functions ([#132](https://github.com/cachebag/nmrs/pull/132))
 
 ## [1.0.0] - 2025-12-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "nmrs"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "nmrs-gui"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,17 @@ edition = "2021"
 license = "MIT"
 repository = "https://github.com/cachebag/nmrs"
 
+[workspace.lints.rust]
+unsafe_code = "forbid"
+# This shouldn't apply to nmrs-gui
+# missing_docs = "warn"
+unused = { level = "warn", priority = -1 }
+
+[workspace.lints.clippy]
+# Allow some common patterns
+too_many_arguments = "allow"
+type_complexity = "allow"
+
 [workspace.dependencies]
 # Core dependencies
 zbus = "5.12.0"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=nmrs
-pkgver=1.0.0
+pkgver=1.1.0
 pkgrel=1
 pkgdesc="Wayland-native GUI for NetworkManager, built with Rust and GTK4"
 arch=('x86_64')
@@ -9,16 +9,16 @@ depends=('gtk4' 'libadwaita' 'networkmanager')
 makedepends=('cargo' 'git')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/cachebag/nmrs/archive/v0.3.0-beta.tar.gz"
         "nmrs.desktop")
-sha256sums=('f9175dfe4dd7c86b585d9218a6953aa2720b7439be31c225b7fee896fff34d7b'
-            '2279f157e299d52fabad1dfd9abd9e862b48dbba83921680f5134a537db061ef')
+sha256sums=('c1c7ea585719342edd780b269b84a1866a7f23ae79fec68e9000f9e9fafbd21d'
+            '7edd410b32d7dac8db3cfa425fd7bfc48681948e3766991f28de39f6674a082a')
 
 build() {
-    cd "$srcdir/${pkgname}-0.3.0-beta"
+    cd "$srcdir/${pkgname}-${pkgver}"
     cargo build --release --locked
 }
 
 package() {
-    cd "$srcdir/${pkgname}-0.3.0-beta"
+    cd "$srcdir/${pkgname}-${pkgver}"
     install -Dm755 "target/release/nmrs-gui" "$pkgdir/usr/bin/nmrs"
     install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
     install -Dm644 "$srcdir/nmrs.desktop" "$pkgdir/usr/share/applications/$pkgname.desktop"

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ async fn main() -> nmrs::Result<()> {
 ```
 # <p align="center"> nmrs-gui </p>
 
-![Version](https://img.shields.io/badge/nmrs--gui-0.5.0--beta-orange?style=flat-square)
+![Version](https://img.shields.io/badge/nmrs--gui-1.1.0-orange?style=flat-square)
 
 This repository also includes `nmrs-gui`, a Wayland-compatible NetworkManager frontend built with GTK4.
 

--- a/nmrs-gui/Cargo.toml
+++ b/nmrs-gui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nmrs-gui"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Akrm Al-Hakimi <alhakimiakrmj@gmail.com>"]
 edition.workspace = true
 rust-version = "1.85.1"
@@ -11,7 +11,7 @@ keywords = ["networkmanager", "gui", "gtk", "linux"]
 categories = ["gui"]
 
 [dependencies]
-nmrs = { path = "../nmrs", version = "1.0.1" }
+nmrs = { path = "../nmrs", version = "1.1.0" }
 gtk = { version = "0.10.3", package = "gtk4" }
 glib = "0.21.5"
 tokio = { version = "1.48.0", features = ["full"] }

--- a/nmrs.desktop
+++ b/nmrs.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=nmrs
+Name=nmrs-gui
 Comment=Wayland-native NetworkManager GUI
 Exec=nmrs-gui
 Icon=network-wireless

--- a/nmrs/Cargo.toml
+++ b/nmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nmrs"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Akrm Al-Hakimi <alhakimiakrmj@gmail.com>"]
 edition.workspace = true
 rust-version = "1.78.0"
@@ -28,3 +28,17 @@ tokio.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true
+
+[lib]
+bench = false
+
+[[example]]
+name = "wifi_scan"
+path = "examples/wifi_scan.rs"
+
+[[example]]
+name = "vpn_connect"
+path = "examples/vpn_connect.rs"

--- a/package.nix
+++ b/package.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage {
 
   src = ./.;
 
-  cargoHash = "sha256-YxRzNhHjurbhsoDY12EMCqRKSLMkcD8WFqIYNHdr0QQ=";
+  cargoHash = "sha256-uvH7OtKT0laBXyfv70rV5XQKPHZBmRmr1p2y9Wxom7E=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
Bump versions for both `nmrs` and `nmrs-gui`

Also update CHANGELOG, `Cargo.toml` fields and Nix sha