### PR TITLE
perf: borrowed slice adjusted for empty ssid check

### DIFF
--- a/nmrs/src/monitoring/info.rs
+++ b/nmrs/src/monitoring/info.rs
@@ -153,7 +153,7 @@ pub(crate) async fn current_ssid(conn: &Connection) -> Option<String> {
                 );
                 let ssid_bytes = try_log!(ap.ssid().await, "Failed to get SSID bytes");
                 let ssid = decode_ssid_or_empty(&ssid_bytes);
-                return Some(ssid);
+                return Some(ssid.to_string());
             }
         }
     }
@@ -199,7 +199,7 @@ pub(crate) async fn current_connection_info(conn: &Connection) -> Option<(String
                 let ssid_bytes = try_log!(ap.ssid().await, "Failed to get SSID bytes");
                 let ssid = decode_ssid_or_empty(&ssid_bytes);
                 let frequency = ap.frequency().await.ok();
-                return Some((ssid, frequency));
+                return Some((ssid.to_string(), frequency));
             }
         }
     }

--- a/nmrs/src/util/utils.rs
+++ b/nmrs/src/util/utils.rs
@@ -77,16 +77,18 @@ pub(crate) fn decode_ssid_or_hidden(bytes: &[u8]) -> Cow<'static, str> {
 }
 
 /// Decode SSID bytes for comparison purposes, defaulting to empty string if invalid.
-pub(crate) fn decode_ssid_or_empty(bytes: &[u8]) -> String {
+pub(crate) fn decode_ssid_or_empty(bytes: &[u8]) -> Cow<'static, str> {
     if bytes.is_empty() {
-        return String::new();
+        return Cow::Borrowed("");
     }
-    str::from_utf8(bytes)
-        .map(|s| s.to_string())
-        .unwrap_or_else(|e| {
+
+    match str::from_utf8(bytes) {
+        Ok(s) => Cow::Owned(s.to_owned()),
+        Err(e) => {
             warn!("Invalid UTF-8 in SSID during comparison: {e}");
-            String::new()
-        })
+            Cow::Borrowed("")
+        }
+    }
 }
 
 /// Safely get signal strength with a default value.


### PR DESCRIPTION
Change `decode_ssid_or_empty` to return a borrowed slice instead of `String`