### PR TITLE
fix: change `Dockerfile` to only configure `nmrs`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -7,19 +7,23 @@ RUN apt-get update && apt-get install -y \
     dbus \
     build-essential \
     curl \
+    pkg-config \
+    libdbus-1-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Rust toolchain
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-RUN mkdir -p /run/dbus
+# DBus runtime dirs
+RUN mkdir -p /run/dbus /run/NetworkManager
 
 WORKDIR /app
 
 COPY Cargo.toml Cargo.lock ./
 COPY nmrs ./nmrs
-COPY nmrs-gui ./nmrs-gui
 
-RUN mkdir -p /run/NetworkManager
+ENV CARGO_NET_OFFLINE=false
 
-CMD ["sh", "-c", "dbus-daemon --system --fork && sleep 1 && NetworkManager --no-daemon &  sleep 3 && cargo test -p nmrs"]
+CMD ["sh", "-c", "dbus-daemon --system --fork && sleep 1 && NetworkManager --no-daemon & sleep 3 && cargo test -p nmrs"]
+


### PR DESCRIPTION
Change the Docker image to only configure `nmrs`. The GUI should only be built on Linux, I don't feel like wrapping my head around putting a band-aid on that too