### PR TITLE
fix: nmrs empty password handling

### DIFF
--- a/nmrs/src/api/models.rs
+++ b/nmrs/src/api/models.rs
@@ -1082,6 +1082,10 @@ pub enum ConnectionError {
     #[error("no saved connection for network")]
     NoSavedConnection,
 
+    /// Invalid credentials for the request network
+    #[error("invalid credentials for network")]
+    InvalidCredentials,
+
     /// A general connection failure with a device state reason code.
     #[error("connection failed: {0}")]
     DeviceFailed(StateReason),

--- a/nmrs/src/core/connection.rs
+++ b/nmrs/src/core/connection.rs
@@ -644,7 +644,7 @@ fn decide_saved_connection(
         Some(path) => Ok(SavedDecision::UseSaved(path)),
 
         None if matches!(creds, WifiSecurity::WpaPsk { psk } if psk.trim().is_empty()) => {
-            Err(ConnectionError::NoSavedConnection)
+            Err(ConnectionError::InvalidCredentials)
         }
 
         None => Ok(SavedDecision::RebuildFresh),

--- a/nmrs/tests/validation_test.rs
+++ b/nmrs/tests/validation_test.rs
@@ -289,4 +289,5 @@ fn test_connection_error_types() {
     let _err6 = ConnectionError::InvalidPeers("test".to_string());
     let _err7 = ConnectionError::InvalidPrivateKey("test".to_string());
     let _err8 = ConnectionError::InvalidPublicKey("test".to_string());
+    let _err9 = ConnectionError::InvalidCredentials;
 }


### PR DESCRIPTION
This PR adds a new InvalidCredentials variant to the ConnectionError enum and updates the connection decision logic to validate PSK credentials.

Fixes #176 