### PR TITLE
ci: auto-update nix hashes on PRs

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -8,11 +8,39 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: read
+      contents: write
     steps:
       - uses: actions/checkout@v6
 
+      - uses: DeterminateSystems/determinate-nix-action@v3
+
+      - uses: DeterminateSystems/flakehub-cache-action@main
+
       - name: Install Nix
         uses: cachix/install-nix-action@v31
+
+      - name: Fix hash mismatches
+        if: failure() && github.event_name == 'pull_request'
+        id: fix-hashes
+        run: |
+          git stash --include-untracked
+          git fetch --depth=1 origin "$GITHUB_HEAD_REF"
+          git checkout -B "$GITHUB_HEAD_REF" "${{ github.event.pull_request.head.sha }}"
+ 
+          determinate-nixd fix hashes --auto-apply
+ 
+          if ! git diff --quiet; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add --update --ignore-removal .
+            git commit -m "[dependabot skip] Automatically fix Nix hashes"
+            git push origin "$GITHUB_HEAD_REF"
+          fi
+ 
+          git checkout -
+          git stash pop || true
 
       - name: Build package
         run: nix build -f default.nix


### PR DESCRIPTION
This change to the nix workflow should auto-update the hash if we ever end up changing `Cargo.lock` by addind/removing/bumping deps.