### PR TITLE
fix(docs): updating windowrule in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ nix-shell -p nmrs
 **Tiling Window Managers** (Hyprland, Sway, i3)
 
 ```
-windowrulev2 = float, class:^(org\.nmrs\.ui)$
+windowrule = float 1, match:class org.nmrs.ui
 ```
 
 **Custom Styling**


### PR DESCRIPTION
Waybar's config for windowrule seems to have changed, original config broke tiling.