### PR TITLE
fix(tests): idempotence enforcement for `forget_vpn()`

### DIFF
--- a/nmrs/tests/integration_test.rs
+++ b/nmrs/tests/integration_test.rs
@@ -790,7 +790,8 @@ async fn forget_returns_no_saved_connection_error() {
             panic!("Expected NoSavedConnection error, got: {}", e);
         }
         Ok(_) => {
-            panic!("Expected error, got success");
+            // Error is Expected in case of failed operation only.
+            println!("Expected response, got success");
         }
     }
 }
@@ -951,10 +952,11 @@ async fn test_forget_nonexistent_vpn() {
         .await
         .expect("Failed to create NetworkManager");
 
-    // Forgetting a non-existent VPN should fail
+    // Forgetting a non-existent VPN will return Ok
+    // Error is Expected in case of failed operation only
     let result = nm.forget_vpn("nonexistent_vpn_connection_12345").await;
     assert!(
-        result.is_err(),
+        result.is_ok(),
         "Forgetting non-existent VPN should return error"
     );
 
@@ -966,7 +968,7 @@ async fn test_forget_nonexistent_vpn() {
             panic!("Unexpected error type: {}", e);
         }
         Ok(_) => {
-            panic!("Should have failed");
+            println!("Correct response: NoSavedConnection");
         }
     }
 }


### PR DESCRIPTION
**Summary**

This PR makes the suggested changes for integration test.

As per  #200  the forget and forget_vpn methods are idempotent, and in case of no-existent profile/connection it should not fail.

Previously error was expected in these cases. But after #200 we should get Ok( ( ) ).

---

**Changes**

- Updated test_forget_nonexistent_vpn test to expect Ok( ( ) ), and  prevent panic in case of Ok response.
- Updated forget_returns_no_saved_connection_error  test to not panic in case of Ok repsonse.