### PR TITLE
refactor(bluetooth): replace println! with debug!

### DIFF
--- a/nmrs/src/core/bluetooth.rs
+++ b/nmrs/src/core/bluetooth.rs
@@ -171,7 +171,7 @@ pub(crate) async fn connect_bluetooth(
 
             let connection_settings = bluetooth::build_bluetooth_connection(name, settings, &opts);
 
-            println!(
+            debug!(
                 "Creating Bluetooth connection with settings: {:#?}",
                 connection_settings
             );


### PR DESCRIPTION
Swapping leftover `println1` to `debug!` in `bluetooth.rs`.

Closes #211