### PR TITLE
refactor(#224): replace hardcoded root paths with Default impl

### DIFF
--- a/nmrs/src/core/connection.rs
+++ b/nmrs/src/core/connection.rs
@@ -151,7 +151,7 @@ pub(crate) async fn connect_wired(
     let saved = get_saved_connection_path(conn, &interface).await?;
 
     // For Ethernet, we use "/" as the specific_object (no access point needed)
-    let specific_object = OwnedObjectPath::try_from("/").unwrap();
+    let specific_object = OwnedObjectPath::default();
 
     match saved {
         Some(saved_path) => {

--- a/nmrs/src/core/vpn.rs
+++ b/nmrs/src/core/vpn.rs
@@ -53,8 +53,8 @@ pub(crate) async fn connect_vpn(
         crate::core::connection_settings::get_saved_connection_path(conn, &creds.name).await?;
 
     // For WireGuard activation, always use "/" as device path - NetworkManager will auto-select
-    let vpn_device_path = OwnedObjectPath::try_from("/").unwrap();
-    let specific_object = OwnedObjectPath::try_from("/").unwrap();
+    let vpn_device_path = OwnedObjectPath::default();
+    let specific_object = OwnedObjectPath::default();
 
     let active_conn = if let Some(saved_path) = saved {
         debug!("Activating existent VPN connection");

--- a/nmrs/tests/validation_test.rs
+++ b/nmrs/tests/validation_test.rs
@@ -4,6 +4,7 @@
 //! D-Bus operations, providing clear error messages to users.
 
 use nmrs::{ConnectionError, EapOptions, VpnCredentials, VpnType, WifiSecurity, WireGuardPeer};
+use zvariant::OwnedObjectPath;
 
 #[test]
 fn test_invalid_ssid_empty() {
@@ -245,6 +246,12 @@ fn test_valid_vpn_credentials() {
     assert!(creds.gateway.contains(':'));
     assert!(!creds.peers.is_empty());
     assert!(creds.mtu.unwrap() >= 576 && creds.mtu.unwrap() <= 9000);
+}
+
+#[test]
+fn test_default_object_path() {
+    let object_path = OwnedObjectPath::try_from("/").unwrap();
+    assert_eq!(object_path, OwnedObjectPath::default())
 }
 
 #[test]


### PR DESCRIPTION
Fixes #224.
I'm not sure if `validation_test.rs` is the best place to check the equality though.