### PR TITLE
refactor(nmrs-gui): elide use of `WiredDevicesContext` and just use `NetworksContext` instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "nmrs"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "async-trait",
  "base64",

--- a/nmrs-gui/src/ui/header.rs
+++ b/nmrs-gui/src/ui/header.rs
@@ -278,18 +278,8 @@ pub async fn refresh_networks(
                 wired_header.set_margin_start(12);
                 list_container.append(&wired_header);
 
-                // Create a wired devices context
-                let wired_ctx = wired_devices::WiredDevicesContext {
-                    nm: ctx.nm.clone(),
-                    on_success: ctx.on_success.clone(),
-                    status: ctx.status.clone(),
-                    stack: ctx.stack.clone(),
-                    parent_window: ctx.parent_window.clone(),
-                };
-                let wired_ctx = Rc::new(wired_ctx);
-
                 let wired_list = wired_devices::wired_devices_view(
-                    wired_ctx,
+                    ctx.clone(),
                     &available_devices,
                     ctx.wired_details_page.clone(),
                 );
@@ -442,17 +432,8 @@ pub async fn refresh_networks_no_scan(
             wired_header.set_margin_start(12);
             list_container.append(&wired_header);
 
-            let wired_ctx = wired_devices::WiredDevicesContext {
-                nm: ctx.nm.clone(),
-                on_success: ctx.on_success.clone(),
-                status: ctx.status.clone(),
-                stack: ctx.stack.clone(),
-                parent_window: ctx.parent_window.clone(),
-            };
-            let wired_ctx = Rc::new(wired_ctx);
-
             let wired_list = wired_devices::wired_devices_view(
-                wired_ctx,
+                ctx.clone(),
                 &available_devices,
                 ctx.wired_details_page.clone(),
             );

--- a/nmrs-gui/src/ui/wired_devices.rs
+++ b/nmrs-gui/src/ui/wired_devices.rs
@@ -2,32 +2,25 @@ use gtk::prelude::*;
 use gtk::Align;
 use gtk::GestureClick;
 use gtk::{Box, Image, Label, ListBox, ListBoxRow, Orientation};
-use nmrs::{models, NetworkManager};
+use nmrs::models;
 use std::rc::Rc;
 
+use crate::ui::networks::NetworksContext;
 use crate::ui::wired_page::WiredPage;
 
 pub struct WiredDeviceRowController {
     pub row: gtk::ListBoxRow,
     pub arrow: gtk::Image,
-    pub ctx: Rc<WiredDevicesContext>,
+    pub ctx: Rc<NetworksContext>,
     pub device: models::Device,
     pub details_page: Rc<WiredPage>,
-}
-
-pub struct WiredDevicesContext {
-    pub nm: Rc<NetworkManager>,
-    pub on_success: Rc<dyn Fn()>,
-    pub status: Label,
-    pub stack: gtk::Stack,
-    pub parent_window: gtk::ApplicationWindow,
 }
 
 impl WiredDeviceRowController {
     pub fn new(
         row: gtk::ListBoxRow,
         arrow: gtk::Image,
-        ctx: Rc<WiredDevicesContext>,
+        ctx: Rc<NetworksContext>,
         device: models::Device,
         details_page: Rc<WiredPage>,
     ) -> Self {
@@ -108,7 +101,7 @@ impl WiredDeviceRowController {
 }
 
 pub fn wired_devices_view(
-    ctx: Rc<WiredDevicesContext>,
+    ctx: Rc<NetworksContext>,
     devices: &[models::Device],
     details_page: Rc<WiredPage>,
 ) -> ListBox {


### PR DESCRIPTION
Closes #222 