### PR TITLE
fix(nmrs): allow NetworkManager to negotiate best protocol and cipher

### DIFF
--- a/nmrs/src/api/builders/wifi_builder.rs
+++ b/nmrs/src/api/builders/wifi_builder.rs
@@ -417,6 +417,12 @@ mod tests {
             Some(&Value::from("password123".to_string()))
         );
 
+        // proto/pairwise/group must not be set so NetworkManager can
+        // negotiate with mixed-mode (WPA1+WPA2) access points.
+        assert!(security.get("proto").is_none());
+        assert!(security.get("pairwise").is_none());
+        assert!(security.get("group").is_none());
+
         let wireless = settings.get("802-11-wireless").unwrap();
         assert_eq!(
             wireless.get("security"),


### PR DESCRIPTION
We hardcoded ["rsn"] (WPA2 only) and cipher to ["ccmp"] (AES only). When a router offers WPA1+WPA2 mixed mode, if the AP negotiates WPA1/TKIP first, the connection fails because nmrs told NetworkManager to only accept RSN/CCMP.

Fixes #270