### PR TITLE
fix(#273): user CSS now overrides selected theme

### DIFF
--- a/nmrs-gui/CHANGELOG.md
+++ b/nmrs-gui/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the `nmrs-gui` crate will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Custom `~/.config/nmrs/style.css` is now applied after the saved theme, ensuring it always takes precedence over any predefined theme ([#274](https://github.com/cachebag/nmrs/pull/274))
+
 ## [1.1.0] - 2025-12-19
 
 ### Fixed

--- a/nmrs-gui/src/style.rs
+++ b/nmrs-gui/src/style.rs
@@ -4,10 +4,17 @@ use gtk::{CssProvider, STYLE_PROVIDER_PRIORITY_APPLICATION, STYLE_PROVIDER_PRIOR
 use std::fs;
 use std::io::Write;
 
-fn load_user_css_if_exists(display: &Display, default: &str) {
+/// Load and apply the user's custom ~/.config/nmrs/style.css.
+/// If the file does not exist it is created with the bundled defaults.
+/// This must be called after any theme provider is registered so that
+/// same-priority (STYLE_PROVIDER_PRIORITY_USER) rules resolve in favour of
+/// the user's stylesheet.
+pub fn load_user_css() {
     let path = dirs::config_dir()
         .unwrap_or_default()
         .join("nmrs/style.css");
+
+    let display = Display::default().expect("No display found");
 
     if path.exists() {
         let provider = CssProvider::new();
@@ -16,7 +23,7 @@ fn load_user_css_if_exists(display: &Display, default: &str) {
         provider.load_from_file(&file);
 
         gtk::style_context_add_provider_for_display(
-            display,
+            &display,
             &provider,
             STYLE_PROVIDER_PRIORITY_USER,
         );
@@ -25,6 +32,7 @@ fn load_user_css_if_exists(display: &Display, default: &str) {
             fs::create_dir_all(parent).ok();
         }
 
+        let default = include_str!("style.css");
         let mut f = fs::File::create(&path).expect("Failed to create CSS file");
         f.write_all(default.as_bytes())
             .expect("Failed to write default CSS");
@@ -44,6 +52,4 @@ pub fn load_css() {
         &provider,
         STYLE_PROVIDER_PRIORITY_APPLICATION,
     );
-
-    load_user_css_if_exists(&display, css);
 }

--- a/nmrs-gui/src/ui/header.rs
+++ b/nmrs-gui/src/ui/header.rs
@@ -97,6 +97,9 @@ pub fn build_header(
             );
 
             crate::theme_config::save_theme(theme.key);
+
+            // Re-register user CSS after the new theme so it keeps priority.
+            crate::style::load_user_css();
         }
     });
 

--- a/nmrs-gui/src/ui/mod.rs
+++ b/nmrs-gui/src/ui/mod.rs
@@ -48,6 +48,10 @@ pub fn build_ui(app: &Application) {
         }
     }
 
+    // User's custom style.css must be registered after the theme so that it
+    // takes precedence when both run at STYLE_PROVIDER_PRIORITY_USER.
+    crate::style::load_user_css();
+
     let vbox = GtkBox::new(Orientation::Vertical, 0);
     let status = Label::new(None);
     let list_container = GtkBox::new(Orientation::Vertical, 0);


### PR DESCRIPTION
Closes #273

Both the saved theme (on startup) and live theme switches were registered at the same GTK CSS priority (800) as the user's `style.css`, but after it- so the theme always won. The fix loads `style.css` last, making it register after the theme and take precedence