### PR TITLE
fix(#243) set proper package name and version in nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,8 @@
           };
 
         packages.default = naersk-package.buildPackage {
-          pname = "nmrs";
+          name = "nmrs";
+          version = self.shortRev or self.dirtyShortRev;
           src = ./.;
 
           buildInputs = with pkgs; [


### PR DESCRIPTION
Sets the correct attributes on the `naersk.buildPackage` call so that now we get derivation names like `nmrs-3a85a13` instead of `rust-workspace-unknown`

Fixes #243 