### PR TITLE
fix(#278): header status label inflates natural width with long status strings

### DIFF
--- a/nmrs-gui/src/ui/mod.rs
+++ b/nmrs-gui/src/ui/mod.rs
@@ -7,8 +7,8 @@ pub mod wired_page;
 
 use gtk::prelude::*;
 use gtk::{
-    Application, ApplicationWindow, Box as GtkBox, Label, Orientation, ScrolledWindow, Spinner,
-    Stack, STYLE_PROVIDER_PRIORITY_USER,
+    pango::EllipsizeMode, Application, ApplicationWindow, Box as GtkBox, Label, Orientation,
+    ScrolledWindow, Spinner, Stack, STYLE_PROVIDER_PRIORITY_USER,
 };
 use std::cell::Cell;
 use std::rc::Rc;
@@ -54,6 +54,9 @@ pub fn build_ui(app: &Application) {
 
     let vbox = GtkBox::new(Orientation::Vertical, 0);
     let status = Label::new(None);
+    status.set_xalign(0.0);
+    status.set_ellipsize(EllipsizeMode::End);
+    status.set_max_width_chars(36);
     let list_container = GtkBox::new(Orientation::Vertical, 0);
     let stack = Stack::new();
     let is_scanning = Rc::new(Cell::new(false));


### PR DESCRIPTION
#278 

### Motivation
The header status label was inflating natural width with long strings, making compositor width behavior look ignored.

### Description
This PR applies a surgical change in `nmrs-gui/src/ui/mod.rs`:
- import `pango::EllipsizeMode`
- set `status.set_xalign(0.0)`
- set `status.set_ellipsize(EllipsizeMode::End)`
- set `status.set_max_width_chars(36)`

No changes were made to `networks.rs`, `wired_devices.rs`, CSS, Stack/homogeneity, wrapping, or hard size requests/clamps.

### Testing
- `cargo fmt --all` ✅
- `cargo test -p nmrs --all-features` ✅
- `cargo test -p nmrs-gui` ⚠️ could not run in this environment due to missing system GTK/GLib development libraries (`glib-2.0.pc` not found via `pkg-config`).

### AI disclosure
Per `CONTRIBUTING.md`, AI assistance was used to implement this small change and draft the PR description. I reviewed the diff and outputs before submission.