### PR TITLE
refactor(#289): `connect_vpn` sig and new `VpnConfig` trait

### DIFF
--- a/nmrs/CHANGELOG.md
+++ b/nmrs/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to the `nmrs` crate will be documented in this file.
 
 ## [Unreleased]
+### Changed
+- Introduce `VpnConfig` trait and refactor `connect_vpn` signature ([#303](https://github.com/cachebag/nmrs/pull/303))
 
 ## [2.2.0] - 2026-03-17
 ### Added

--- a/nmrs/examples/vpn_connect.rs
+++ b/nmrs/examples/vpn_connect.rs
@@ -1,8 +1,8 @@
 /// Connect to a WireGuard VPN using NetworkManager and print the assigned IP address.
 ///
-/// This example demonstrates using the builder pattern for creating VPN credentials,
-/// which provides a more ergonomic and readable API compared to the traditional constructor.
-use nmrs::{NetworkManager, VpnCredentials, WireGuardPeer};
+/// This example demonstrates creating a `WireGuardConfig`,
+/// the preferred API for configuring VPN connections.
+use nmrs::{NetworkManager, WireGuardConfig, WireGuardPeer};
 
 #[tokio::main]
 async fn main() -> nmrs::Result<()> {
@@ -16,16 +16,14 @@ async fn main() -> nmrs::Result<()> {
     )
     .with_persistent_keepalive(25);
 
-    // Use the builder pattern for a more readable configuration
-    let creds = VpnCredentials::builder()
-        .name("ExampleVPN")
-        .wireguard()
-        .gateway("vpn.example.com:51820")
-        .private_key(std::env::var("WG_PRIVATE_KEY").expect("Set WG_PRIVATE_KEY env var"))
-        .address("10.0.0.2/24")
-        .add_peer(peer)
-        .with_dns(vec!["1.1.1.1".into()])
-        .build();
+    let creds = WireGuardConfig::new(
+        "ExampleVPN",
+        "vpn.example.com:51820",
+        std::env::var("WG_PRIVATE_KEY").expect("Set WG_PRIVATE_KEY env var"),
+        "10.0.0.2/24",
+        vec![peer],
+    )
+    .with_dns(vec!["1.1.1.1".into()]);
 
     println!("Connecting to VPN...");
     nm.connect_vpn(creds).await?;

--- a/nmrs/src/api/builders/vpn.rs
+++ b/nmrs/src/api/builders/vpn.rs
@@ -62,6 +62,7 @@
 //! let settings = build_wireguard_connection(&creds, &opts).unwrap();
 //! // Pass settings to NetworkManager's AddAndActivateConnection
 //! ```
+#![allow(deprecated)]
 
 use std::collections::HashMap;
 use zvariant::Value;

--- a/nmrs/src/api/models/tests.rs
+++ b/nmrs/src/api/models/tests.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::time::Duration;
 use uuid::Uuid;
 
@@ -614,6 +616,93 @@ fn test_vpn_credentials_builder_basic() {
     assert_eq!(creds.peers.len(), 1);
     assert!(creds.dns.is_none());
     assert!(creds.mtu.is_none());
+}
+
+#[test]
+fn test_wireguard_config_basic() {
+    let peer = WireGuardPeer::new(
+        "HIgo9xNzJMWLKAShlKl6/bUT1VI9Q0SDBXGtLXkPFXc=",
+        "vpn.example.com:51820",
+        vec!["0.0.0.0/0".into()],
+    );
+
+    let config = WireGuardConfig::new(
+        "TestVPN",
+        "vpn.example.com:51820",
+        "YBk6X3pP8KjKz7+HFWzVHNqL3qTZq8hX9VxFQJ4zVmM=",
+        "10.0.0.2/24",
+        vec![peer],
+    );
+
+    assert_eq!(config.name, "TestVPN");
+    assert_eq!(config.gateway, "vpn.example.com:51820");
+    assert_eq!(
+        config.private_key,
+        "YBk6X3pP8KjKz7+HFWzVHNqL3qTZq8hX9VxFQJ4zVmM="
+    );
+    assert_eq!(config.address, "10.0.0.2/24");
+    assert_eq!(config.peers.len(), 1);
+    assert!(config.dns.is_none());
+    assert!(config.mtu.is_none());
+}
+
+#[test]
+fn test_wireguard_config_implements_vpn_config() {
+    let uuid = Uuid::new_v4();
+    let config = WireGuardConfig::new(
+        "TestVPN",
+        "vpn.example.com:51820",
+        "private_key",
+        "10.0.0.2/24",
+        vec![WireGuardPeer::new(
+            "public_key",
+            "vpn.example.com:51820",
+            vec!["0.0.0.0/0".into()],
+        )],
+    )
+    .with_dns(vec!["1.1.1.1".into(), "8.8.8.8".into()])
+    .with_mtu(1420)
+    .with_uuid(uuid);
+
+    let vpn_config: &dyn VpnConfig = &config;
+
+    assert_eq!(vpn_config.vpn_type(), VpnType::WireGuard);
+    assert_eq!(vpn_config.name(), "TestVPN");
+    assert_eq!(vpn_config.gateway(), "vpn.example.com:51820");
+    assert_eq!(
+        vpn_config.dns(),
+        Some(["1.1.1.1".to_string(), "8.8.8.8".to_string()].as_slice())
+    );
+    assert_eq!(vpn_config.mtu(), Some(1420));
+    assert_eq!(vpn_config.uuid(), Some(uuid));
+}
+
+#[test]
+fn test_wireguard_config_roundtrips_through_vpn_credentials() {
+    let config = WireGuardConfig::new(
+        "TestVPN",
+        "vpn.example.com:51820",
+        "private_key",
+        "10.0.0.2/24",
+        vec![WireGuardPeer::new(
+            "public_key",
+            "vpn.example.com:51820",
+            vec!["0.0.0.0/0".into()],
+        )],
+    )
+    .with_dns(vec!["1.1.1.1".into()])
+    .with_mtu(1420);
+
+    let legacy: VpnCredentials = config.clone().into();
+    let roundtrip = WireGuardConfig::from(legacy);
+
+    assert_eq!(roundtrip.name, config.name);
+    assert_eq!(roundtrip.gateway, config.gateway);
+    assert_eq!(roundtrip.private_key, config.private_key);
+    assert_eq!(roundtrip.address, config.address);
+    assert_eq!(roundtrip.peers.len(), config.peers.len());
+    assert_eq!(roundtrip.dns, config.dns);
+    assert_eq!(roundtrip.mtu, config.mtu);
 }
 
 #[test]

--- a/nmrs/src/api/models/vpn.rs
+++ b/nmrs/src/api/models/vpn.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use uuid::Uuid;
 
 use super::device::DeviceState;
@@ -7,20 +9,39 @@ use super::device::DeviceState;
 /// Identifies the VPN protocol/technology used for the connection.
 /// Currently only WireGuard is supported.
 #[non_exhaustive]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VpnType {
     /// WireGuard - modern, high-performance VPN protocol.
     WireGuard,
 }
 
-/// VPN Credentials for establishing a VPN connection.
+/// Common metadata shared by VPN connection configurations.
+pub trait VpnConfig: Send + Sync + std::fmt::Debug {
+    /// Returns the VPN protocol used by this configuration.
+    fn vpn_type(&self) -> VpnType;
+
+    /// Returns the connection name.
+    fn name(&self) -> &str;
+
+    /// Returns the gateway endpoint.
+    fn gateway(&self) -> &str;
+
+    /// Returns the configured DNS servers, if any.
+    fn dns(&self) -> Option<&[String]>;
+
+    /// Returns the configured MTU, if any.
+    fn mtu(&self) -> Option<u32>;
+
+    /// Returns the configured UUID, if any.
+    fn uuid(&self) -> Option<Uuid>;
+}
+
+/// WireGuard configuration for establishing a VPN connection.
 ///
 /// Stores the necessary information to configure and connect to a VPN.
-/// Currently supports WireGuard VPN connections.
 ///
 /// # Fields
 ///
-/// - `vpn_type`: The type of VPN (currently only WireGuard)
 /// - `name`: Unique identifier for the connection
 /// - `gateway`: VPN gateway endpoint (e.g., "vpn.example.com:51820")
 /// - `private_key`: Client's WireGuard private key
@@ -33,7 +54,7 @@ pub enum VpnType {
 /// # Example
 ///
 /// ```rust
-/// use nmrs::{VpnCredentials, VpnType, WireGuardPeer};
+/// use nmrs::{WireGuardConfig, WireGuardPeer};
 ///
 /// let peer = WireGuardPeer::new(
 ///     "server_public_key",
@@ -41,8 +62,7 @@ pub enum VpnType {
 ///     vec!["0.0.0.0/0".into()],
 /// ).with_persistent_keepalive(25);
 ///
-/// let creds = VpnCredentials::new(
-///     VpnType::WireGuard,
+/// let config = WireGuardConfig::new(
 ///     "HomeVPN",
 ///     "vpn.home.com:51820",
 ///     "aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789=",
@@ -50,6 +70,151 @@ pub enum VpnType {
 ///     vec![peer],
 /// ).with_dns(vec!["1.1.1.1".into()]);
 /// ```
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct WireGuardConfig {
+    /// Unique name for the connection profile.
+    pub name: String,
+    /// VPN gateway endpoint (e.g., "vpn.example.com:51820").
+    pub gateway: String,
+    /// Client's WireGuard private key (base64 encoded).
+    pub private_key: String,
+    /// Client's IP address with CIDR notation (e.g., "10.0.0.2/24").
+    pub address: String,
+    /// List of WireGuard peers to connect to.
+    pub peers: Vec<WireGuardPeer>,
+    /// Optional DNS servers to use when connected.
+    pub dns: Option<Vec<String>>,
+    /// Optional Maximum Transmission Unit size.
+    pub mtu: Option<u32>,
+    /// Optional UUID for the connection (auto-generated if not provided).
+    pub uuid: Option<Uuid>,
+}
+
+impl WireGuardConfig {
+    /// Creates new `WireGuardConfig` with the required fields.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use nmrs::{WireGuardConfig, WireGuardPeer};
+    ///
+    /// let peer = WireGuardPeer::new(
+    ///     "server_public_key",
+    ///     "vpn.example.com:51820",
+    ///     vec!["0.0.0.0/0".into()],
+    /// );
+    ///
+    /// let config = WireGuardConfig::new(
+    ///     "MyVPN",
+    ///     "vpn.example.com:51820",
+    ///     "client_private_key",
+    ///     "10.0.0.2/24",
+    ///     vec![peer],
+    /// );
+    /// ```
+    pub fn new(
+        name: impl Into<String>,
+        gateway: impl Into<String>,
+        private_key: impl Into<String>,
+        address: impl Into<String>,
+        peers: Vec<WireGuardPeer>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            gateway: gateway.into(),
+            private_key: private_key.into(),
+            address: address.into(),
+            peers,
+            dns: None,
+            mtu: None,
+            uuid: None,
+        }
+    }
+
+    /// Sets the DNS servers to use when connected.
+    #[must_use]
+    pub fn with_dns(mut self, dns: Vec<String>) -> Self {
+        self.dns = Some(dns);
+        self
+    }
+
+    /// Sets the MTU (Maximum Transmission Unit) size.
+    #[must_use]
+    pub fn with_mtu(mut self, mtu: u32) -> Self {
+        self.mtu = Some(mtu);
+        self
+    }
+
+    /// Sets the UUID for the connection.
+    #[must_use]
+    pub fn with_uuid(mut self, uuid: Uuid) -> Self {
+        self.uuid = Some(uuid);
+        self
+    }
+}
+
+impl VpnConfig for WireGuardConfig {
+    fn vpn_type(&self) -> VpnType {
+        VpnType::WireGuard
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn gateway(&self) -> &str {
+        &self.gateway
+    }
+
+    fn dns(&self) -> Option<&[String]> {
+        self.dns.as_deref()
+    }
+
+    fn mtu(&self) -> Option<u32> {
+        self.mtu
+    }
+
+    fn uuid(&self) -> Option<Uuid> {
+        self.uuid
+    }
+}
+
+impl From<WireGuardConfig> for VpnCredentials {
+    fn from(config: WireGuardConfig) -> Self {
+        Self {
+            vpn_type: VpnType::WireGuard,
+            name: config.name,
+            gateway: config.gateway,
+            private_key: config.private_key,
+            address: config.address,
+            peers: config.peers,
+            dns: config.dns,
+            mtu: config.mtu,
+            uuid: config.uuid,
+        }
+    }
+}
+
+impl From<VpnCredentials> for WireGuardConfig {
+    fn from(config: VpnCredentials) -> Self {
+        Self {
+            name: config.name,
+            gateway: config.gateway,
+            private_key: config.private_key,
+            address: config.address,
+            peers: config.peers,
+            dns: config.dns,
+            mtu: config.mtu,
+            uuid: config.uuid,
+        }
+    }
+}
+
+/// Legacy VPN credentials for establishing a VPN connection.
+///
+/// Prefer [`WireGuardConfig`] for new WireGuard connections.
+#[deprecated(note = "Use WireGuardConfig instead.")]
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct VpnCredentials {
@@ -75,6 +240,8 @@ pub struct VpnCredentials {
 
 impl VpnCredentials {
     /// Creates new `VpnCredentials` with the required fields.
+    ///
+    /// Prefer [`WireGuardConfig::new`] for new code.
     ///
     /// # Examples
     ///
@@ -118,31 +285,6 @@ impl VpnCredentials {
     }
 
     /// Creates a new `VpnCredentials` builder.
-    ///
-    /// This provides a more ergonomic way to construct VPN credentials with a fluent API,
-    /// making it harder to mix up parameter order and easier to see what each value represents.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use nmrs::{VpnCredentials, VpnType, WireGuardPeer};
-    ///
-    /// let peer = WireGuardPeer::new(
-    ///     "server_public_key",
-    ///     "vpn.example.com:51820",
-    ///     vec!["0.0.0.0/0".into()],
-    /// );
-    ///
-    /// let creds = VpnCredentials::builder()
-    ///     .name("MyVPN")
-    ///     .wireguard()
-    ///     .gateway("vpn.example.com:51820")
-    ///     .private_key("client_private_key")
-    ///     .address("10.0.0.2/24")
-    ///     .add_peer(peer)
-    ///     .with_dns(vec!["1.1.1.1".into()])
-    ///     .build();
-    /// ```
     #[must_use]
     pub fn builder() -> VpnCredentialsBuilder {
         VpnCredentialsBuilder::default()
@@ -167,6 +309,32 @@ impl VpnCredentials {
     pub fn with_uuid(mut self, uuid: Uuid) -> Self {
         self.uuid = Some(uuid);
         self
+    }
+}
+
+impl VpnConfig for VpnCredentials {
+    fn vpn_type(&self) -> VpnType {
+        self.vpn_type
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn gateway(&self) -> &str {
+        &self.gateway
+    }
+
+    fn dns(&self) -> Option<&[String]> {
+        self.dns.as_deref()
+    }
+
+    fn mtu(&self) -> Option<u32> {
+        self.mtu
+    }
+
+    fn uuid(&self) -> Option<Uuid> {
+        self.uuid
     }
 }
 

--- a/nmrs/src/api/network_manager.rs
+++ b/nmrs/src/api/network_manager.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use tokio::sync::watch;
 use zbus::Connection;
 
@@ -18,7 +20,7 @@ use crate::core::device::{
 use crate::core::scan::{current_network, list_networks, scan_networks};
 use crate::core::vpn::{connect_vpn, disconnect_vpn, get_vpn_info, list_vpn_connections};
 use crate::models::{
-    BluetoothDevice, BluetoothIdentity, VpnConnection, VpnConnectionInfo, VpnCredentials,
+    BluetoothDevice, BluetoothIdentity, VpnConfig, VpnConnection, VpnConnectionInfo, VpnCredentials,
 };
 use crate::monitoring::device as device_monitor;
 use crate::monitoring::info::show_details;
@@ -265,17 +267,17 @@ impl NetworkManager {
         connect_bluetooth(&self.conn, name, identity, Some(self.timeout_config)).await
     }
 
-    /// Connects to a VPN using the provided credentials.
+    /// Connects to a VPN using the provided configuration.
     ///
     /// Currently supports WireGuard VPN connections. The function checks for an
     /// existing saved VPN connection by name. If found, it activates the saved
     /// connection. If not found, it creates a new VPN connection with the provided
-    /// credentials.
+    /// configuration.
     ///
     /// # Example
     ///
     /// ```rust
-    /// use nmrs::{NetworkManager, VpnCredentials, VpnType, WireGuardPeer};
+    /// use nmrs::{NetworkManager, WireGuardConfig, WireGuardPeer};
     ///
     /// # async fn example() -> nmrs::Result<()> {
     /// let nm = NetworkManager::new().await?;
@@ -286,8 +288,7 @@ impl NetworkManager {
     ///     vec!["0.0.0.0/0".into()],
     /// ).with_persistent_keepalive(25);
     ///
-    /// let creds = VpnCredentials::new(
-    ///     VpnType::WireGuard,
+    /// let config = WireGuardConfig::new(
     ///     "MyVPN",
     ///     "vpn.example.com:51820",
     ///     "your_private_key",
@@ -295,7 +296,7 @@ impl NetworkManager {
     ///     vec![peer],
     /// ).with_dns(vec!["1.1.1.1".into()]);
     ///
-    /// nm.connect_vpn(creds).await?;
+    /// nm.connect_vpn(config).await?;
     /// # Ok(())
     /// # }
     /// ```
@@ -304,10 +305,13 @@ impl NetworkManager {
     ///
     /// Returns an error if:
     /// - NetworkManager is not running or accessible
-    /// - The credentials are invalid or incomplete
+    /// - The configuration is invalid or incomplete
     /// - The VPN connection fails to activate
-    pub async fn connect_vpn(&self, creds: VpnCredentials) -> Result<()> {
-        connect_vpn(&self.conn, creds, Some(self.timeout_config)).await
+    pub async fn connect_vpn<C>(&self, config: C) -> Result<()>
+    where
+        C: VpnConfig + Into<VpnCredentials>,
+    {
+        connect_vpn(&self.conn, config.into(), Some(self.timeout_config)).await
     }
 
     /// Disconnects from an active VPN connection by name.

--- a/nmrs/src/core/vpn.rs
+++ b/nmrs/src/core/vpn.rs
@@ -9,6 +9,7 @@
 //!
 //! These functions are not part of the public API and should be accessed
 //! through the [`NetworkManager`][crate::NetworkManager] interface.
+#![allow(deprecated)]
 
 use log::{debug, info, warn};
 use std::collections::HashMap;

--- a/nmrs/src/lib.rs
+++ b/nmrs/src/lib.rs
@@ -35,7 +35,7 @@
 //! ## VPN Connection (WireGuard)
 //!
 //! ```rust
-//! use nmrs::{NetworkManager, VpnCredentials, VpnType, WireGuardPeer};
+//! use nmrs::{NetworkManager, WireGuardConfig, WireGuardPeer};
 //!
 //! # async fn example() -> nmrs::Result<()> {
 //! let nm = NetworkManager::new().await?;
@@ -47,8 +47,7 @@
 //!     vec!["0.0.0.0/0".into()],
 //! ).with_persistent_keepalive(25);
 //!
-//! let creds = VpnCredentials::new(
-//!     VpnType::WireGuard,
+//! let config = WireGuardConfig::new(
 //!     "MyVPN",
 //!     "vpn.example.com:51820",
 //!     "your_private_key",
@@ -57,7 +56,7 @@
 //! ).with_dns(vec!["1.1.1.1".into(), "8.8.8.8".into()]);
 //!
 //! // Connect to VPN
-//! nm.connect_vpn(creds).await?;
+//! nm.connect_vpn(config).await?;
 //!
 //! // List VPN connections
 //! let vpns = nm.list_vpn_connections().await?;
@@ -88,9 +87,10 @@
 //! - [`Device`] - Represents a network device (WiFi, Ethernet, etc.)
 //! - [`Network`] - Represents a discovered WiFi network
 //! - [`WifiSecurity`] - Security types (Open, WPA-PSK, WPA-EAP)
-//! - [`VpnCredentials`] - VPN connection credentials
+//! - [`VpnCredentials`] - Legacy VPN connection credentials
 //! - [`VpnType`] - Supported VPN types (WireGuard, etc.)
 //! - [`VpnConnection`] - Active VPN connection information
+//! - [`WireGuardConfig`] - Preferred WireGuard connection configuration
 //! - [`WireGuardPeer`] - WireGuard peer configuration
 //! - [`ConnectionError`] - Comprehensive error types
 //!
@@ -315,12 +315,13 @@ pub mod models {
 }
 
 // Re-export commonly used types at crate root for convenience
+#[allow(deprecated)]
 pub use api::models::{
     ActiveConnectionState, BluetoothDevice, BluetoothIdentity, BluetoothNetworkRole,
     ConnectionError, ConnectionOptions, ConnectionStateReason, Device, DeviceState, DeviceType,
-    EapMethod, EapOptions, Network, NetworkInfo, Phase2, StateReason, TimeoutConfig, VpnConnection,
-    VpnConnectionInfo, VpnCredentials, VpnType, WifiSecurity, WireGuardPeer,
-    connection_state_reason_to_error, reason_to_error,
+    EapMethod, EapOptions, Network, NetworkInfo, Phase2, StateReason, TimeoutConfig, VpnConfig,
+    VpnConnection, VpnConnectionInfo, VpnCredentials, VpnType, WifiSecurity, WireGuardConfig,
+    WireGuardPeer, connection_state_reason_to_error, reason_to_error,
 };
 pub use api::network_manager::NetworkManager;
 

--- a/nmrs/src/util/validation.rs
+++ b/nmrs/src/util/validation.rs
@@ -3,6 +3,8 @@
 //! This module provides validation functions for various inputs to ensure
 //! they meet NetworkManager's requirements before attempting D-Bus operations.
 
+#![allow(deprecated)]
+
 use crate::api::models::{ConnectionError, VpnCredentials, WifiSecurity, WireGuardPeer};
 
 /// Maximum SSID length in bytes (802.11 standard).

--- a/nmrs/tests/integration_test.rs
+++ b/nmrs/tests/integration_test.rs
@@ -1,6 +1,6 @@
 use nmrs::{
-    ConnectionError, DeviceState, DeviceType, NetworkManager, StateReason, VpnCredentials, VpnType,
-    WifiSecurity, WireGuardPeer, reason_to_error,
+    ConnectionError, DeviceState, DeviceType, NetworkManager, StateReason, VpnType, WifiSecurity,
+    WireGuardConfig, WireGuardPeer, reason_to_error,
 };
 use std::time::Duration;
 use tokio::time::sleep;
@@ -869,8 +869,8 @@ async fn test_connect_wired() {
     }
 }
 
-/// Helper to create test VPN credentials
-fn create_test_vpn_creds(name: &str) -> VpnCredentials {
+/// Helper to create test VPN configuration
+fn create_test_vpn_creds(name: &str) -> WireGuardConfig {
     let peer = WireGuardPeer::new(
         "HIgo9xNzJMWLKAShlKl6/bUT1VI9Q0SDBXGtLXkPFXc=",
         "test.example.com:51820",
@@ -878,8 +878,7 @@ fn create_test_vpn_creds(name: &str) -> VpnCredentials {
     )
     .with_persistent_keepalive(25);
 
-    VpnCredentials::new(
-        VpnType::WireGuard,
+    WireGuardConfig::new(
         name,
         "test.example.com:51820",
         "YBk6X3pP8KjKz7+HFWzVHNqL3qTZq8hX9VxFQJ4zVmM=",
@@ -1047,13 +1046,12 @@ async fn test_wireguard_peer_structure() {
     assert_eq!(peer.persistent_keepalive, Some(25));
 }
 
-/// Test VPN credentials structure
+/// Test VPN configuration structure
 #[tokio::test]
 async fn test_vpn_credentials_structure() {
     let creds = create_test_vpn_creds("test_credentials");
 
     assert_eq!(creds.name, "test_credentials");
-    assert_eq!(creds.vpn_type, VpnType::WireGuard);
     assert_eq!(creds.peers.len(), 1);
     assert_eq!(creds.address, "10.100.0.2/24");
     assert!(creds.dns.is_some());

--- a/nmrs/tests/validation_test.rs
+++ b/nmrs/tests/validation_test.rs
@@ -3,7 +3,7 @@
 //! These tests verify that invalid inputs are rejected before attempting
 //! D-Bus operations, providing clear error messages to users.
 
-use nmrs::{ConnectionError, EapOptions, VpnCredentials, VpnType, WifiSecurity, WireGuardPeer};
+use nmrs::{ConnectionError, EapOptions, WifiSecurity, WireGuardConfig, WireGuardPeer};
 use zvariant::OwnedObjectPath;
 
 #[test]
@@ -121,8 +121,7 @@ fn test_invalid_vpn_empty_name() {
     )
     .with_persistent_keepalive(25);
 
-    let creds = VpnCredentials::new(
-        VpnType::WireGuard,
+    let creds = WireGuardConfig::new(
         "", // Empty name should be rejected
         "vpn.example.com:51820",
         "YBk6X3pP8KjKz7+HFWzVHNqL3qTZq8hX9VxFQJ4zVmM=",
@@ -144,8 +143,7 @@ fn test_invalid_vpn_gateway_no_port() {
     )
     .with_persistent_keepalive(25);
 
-    let creds = VpnCredentials::new(
-        VpnType::WireGuard,
+    let creds = WireGuardConfig::new(
         "TestVPN",
         "vpn.example.com", // Missing port
         "YBk6X3pP8KjKz7+HFWzVHNqL3qTZq8hX9VxFQJ4zVmM=",
@@ -160,8 +158,7 @@ fn test_invalid_vpn_gateway_no_port() {
 
 #[test]
 fn test_invalid_vpn_no_peers() {
-    let creds = VpnCredentials::new(
-        VpnType::WireGuard,
+    let creds = WireGuardConfig::new(
         "TestVPN",
         "vpn.example.com:51820",
         "YBk6X3pP8KjKz7+HFWzVHNqL3qTZq8hX9VxFQJ4zVmM=",
@@ -183,8 +180,7 @@ fn test_invalid_vpn_bad_cidr() {
     )
     .with_persistent_keepalive(25);
 
-    let creds = VpnCredentials::new(
-        VpnType::WireGuard,
+    let creds = WireGuardConfig::new(
         "TestVPN",
         "vpn.example.com:51820",
         "YBk6X3pP8KjKz7+HFWzVHNqL3qTZq8hX9VxFQJ4zVmM=",
@@ -206,8 +202,7 @@ fn test_invalid_vpn_mtu_too_small() {
     )
     .with_persistent_keepalive(25);
 
-    let creds = VpnCredentials::new(
-        VpnType::WireGuard,
+    let creds = WireGuardConfig::new(
         "TestVPN",
         "vpn.example.com:51820",
         "YBk6X3pP8KjKz7+HFWzVHNqL3qTZq8hX9VxFQJ4zVmM=",
@@ -230,8 +225,7 @@ fn test_valid_vpn_credentials() {
     )
     .with_persistent_keepalive(25);
 
-    let creds = VpnCredentials::new(
-        VpnType::WireGuard,
+    let creds = WireGuardConfig::new(
         "TestVPN",
         "vpn.example.com:51820",
         "YBk6X3pP8KjKz7+HFWzVHNqL3qTZq8hX9VxFQJ4zVmM=",


### PR DESCRIPTION
This PR adds `VpnConfig`, introduces `WireGuardConfig` as the preferred `WireGuard` model, and deprecated `VpnCredentials` while keeping it compatible via `VpnConfig` plus conversion bridges in our vpn module.

`NetworkManager::connect_vpn` now accepts any `C: VpnConfig + Into<VpnCredentials>`
and the docs/examples were updated to use `WireGuardConfig` in the facade and lib. I also re-exported `VpnConfig` and `WireGuardConfig` from the crate root.

Also added coverage for the new type and trait compatibility in our models tests and suppressed internal deprecation noise only in legacy plumbing so downstream users still get the deprecation signal when they use `VpnCredentials`.

Closes #289 