### PR TITLE
feat(#336): parse auth-user-pass and infer OpenVPN auth_type

### DIFF
--- a/nmrs/src/api/models/openvpn.rs
+++ b/nmrs/src/api/models/openvpn.rs
@@ -241,6 +241,14 @@ impl TryFrom<crate::core::ovpn_parser::parser::OvpnFile> for OpenVpnConfig {
             _ => None,
         };
 
+        let has_certs = f.cert.is_some() || f.key.is_some();
+        let auth_type = match (f.auth_user_pass, has_certs) {
+            (true, true) => Some(OpenVpnAuthType::PasswordTls),
+            (true, false) => Some(OpenVpnAuthType::Password),
+            (false, true) => Some(OpenVpnAuthType::Tls),
+            (false, false) => None,
+        };
+
         // FIXME: inline certs (<ca>, <cert>, <key> blocks) are parsed by
         // the .ovpn parser but NM needs them written to temp files or passed
         // via vpn.secrets. For now we return None so the caller knows the cert
@@ -257,7 +265,7 @@ impl TryFrom<crate::core::ovpn_parser::parser::OvpnFile> for OpenVpnConfig {
             remote: first_remote.host,
             port: first_remote.port.unwrap_or(1194),
             tcp,
-            auth_type: None,
+            auth_type,
             auth: f.auth,
             cipher: f.cipher,
             dns: None,
@@ -381,4 +389,47 @@ pub enum OpenVpnProxy {
         port: u16,
         retry: bool,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::ovpn_parser::parser::parse_ovpn;
+
+    fn ovpn_with_remote(extra: &str) -> String {
+        format!("remote vpn.example.com 1194 udp\n{extra}")
+    }
+
+    #[test]
+    fn try_from_auth_user_pass_with_certs_infers_password_tls() {
+        let input =
+            ovpn_with_remote("auth-user-pass\n<cert>\nCERTPEM\n</cert>\n<key>\nKEYPEM\n</key>");
+        let ovpn = parse_ovpn(&input).unwrap();
+        let config = OpenVpnConfig::try_from(ovpn).unwrap();
+        assert_eq!(config.auth_type, Some(OpenVpnAuthType::PasswordTls));
+    }
+
+    #[test]
+    fn try_from_auth_user_pass_without_certs_infers_password() {
+        let input = ovpn_with_remote("auth-user-pass");
+        let ovpn = parse_ovpn(&input).unwrap();
+        let config = OpenVpnConfig::try_from(ovpn).unwrap();
+        assert_eq!(config.auth_type, Some(OpenVpnAuthType::Password));
+    }
+
+    #[test]
+    fn try_from_no_auth_user_pass_with_certs_infers_tls() {
+        let input = ovpn_with_remote("<cert>\nCERTPEM\n</cert>\n<key>\nKEYPEM\n</key>");
+        let ovpn = parse_ovpn(&input).unwrap();
+        let config = OpenVpnConfig::try_from(ovpn).unwrap();
+        assert_eq!(config.auth_type, Some(OpenVpnAuthType::Tls));
+    }
+
+    #[test]
+    fn try_from_no_auth_user_pass_no_certs_infers_none() {
+        let input = ovpn_with_remote("");
+        let ovpn = parse_ovpn(&input).unwrap();
+        let config = OpenVpnConfig::try_from(ovpn).unwrap();
+        assert_eq!(config.auth_type, None);
+    }
 }

--- a/nmrs/src/api/models/openvpn.rs
+++ b/nmrs/src/api/models/openvpn.rs
@@ -241,8 +241,9 @@ impl TryFrom<crate::core::ovpn_parser::parser::OvpnFile> for OpenVpnConfig {
             _ => None,
         };
 
-        let has_certs = f.cert.is_some() || f.key.is_some();
-        let auth_type = match (f.auth_user_pass, has_certs) {
+        // Client certificate auth needs both cert and key; one alone is incomplete.
+        let has_client_cert_pair = f.cert.is_some() && f.key.is_some();
+        let auth_type = match (f.auth_user_pass, has_client_cert_pair) {
             (true, true) => Some(OpenVpnAuthType::PasswordTls),
             (true, false) => Some(OpenVpnAuthType::Password),
             (false, true) => Some(OpenVpnAuthType::Tls),
@@ -431,5 +432,21 @@ mod tests {
         let ovpn = parse_ovpn(&input).unwrap();
         let config = OpenVpnConfig::try_from(ovpn).unwrap();
         assert_eq!(config.auth_type, None);
+    }
+
+    #[test]
+    fn try_from_cert_only_without_auth_user_pass_does_not_infer_tls() {
+        let input = ovpn_with_remote("<cert>\nCERTPEM\n</cert>");
+        let ovpn = parse_ovpn(&input).unwrap();
+        let config = OpenVpnConfig::try_from(ovpn).unwrap();
+        assert_eq!(config.auth_type, None);
+    }
+
+    #[test]
+    fn try_from_cert_only_with_auth_user_pass_infers_password_not_password_tls() {
+        let input = ovpn_with_remote("auth-user-pass\n<cert>\nCERTPEM\n</cert>");
+        let ovpn = parse_ovpn(&input).unwrap();
+        let config = OpenVpnConfig::try_from(ovpn).unwrap();
+        assert_eq!(config.auth_type, Some(OpenVpnAuthType::Password));
     }
 }

--- a/nmrs/src/core/ovpn_parser/parser.rs
+++ b/nmrs/src/core/ovpn_parser/parser.rs
@@ -62,6 +62,11 @@ pub struct OvpnFile {
     // Examples: client, nobind, persist-key, persist-tun.
     pub flags: Vec<String>,
 
+    // auth-user-pass directive. Indicates the server requires
+    // username/password authentication. The optional file path argument
+    // is ignored (NM handles interactive prompts).
+    pub auth_user_pass: bool,
+
     // Catch-all for unmodeled or less common directives.
     // Key = directive name, Value = list of argument lists.
     // Preserves information for round-tripping / forward compatibility.
@@ -149,6 +154,7 @@ struct OvpnFileBuilder {
     allow_compress: Option<AllowCompress>,
     routes: Vec<Route>,
     redirect_gateway: Option<RedirectGateway>,
+    auth_user_pass: bool,
     flags: Vec<String>,
     options: HashMap<String, Vec<String>>,
 }
@@ -177,6 +183,7 @@ impl OvpnFileBuilder {
             allow_compress: self.allow_compress,
             routes: self.routes,
             redirect_gateway: self.redirect_gateway,
+            auth_user_pass: self.auth_user_pass,
             flags: self.flags,
             options: self.options,
         }
@@ -526,6 +533,11 @@ pub fn parse_ovpn(content: &str) -> Result<OvpnFile, ConnectionError> {
                             netmask,
                             gateway,
                         });
+                    }
+                    "auth-user-pass" => {
+                        // auth-user-pass [FILE]
+                        // Optional file path is ignored — NM handles interactive prompts.
+                        b.auth_user_pass = true;
                     }
                     "redirect-gateway" => {
                         let mut rg = RedirectGateway {
@@ -1069,5 +1081,23 @@ mod tests {
             "key-direction",
             OvpnParseError::MissingArgument { key, .. } if key == "key-direction"
         );
+    }
+
+    #[test]
+    fn auth_user_pass_bare_passes() {
+        let result = parse_ok("auth-user-pass");
+        assert!(result.auth_user_pass);
+    }
+
+    #[test]
+    fn auth_user_pass_with_file_path_passes() {
+        let result = parse_ok("auth-user-pass /etc/openvpn/creds.txt");
+        assert!(result.auth_user_pass);
+    }
+
+    #[test]
+    fn auth_user_pass_absent_defaults_false() {
+        let result = parse_ok("remote example.com 1194 udp");
+        assert!(!result.auth_user_pass);
     }
 }


### PR DESCRIPTION
- Add OvpnFile.auth_user_pass; accept optional file path, ignore path
- Map auth_user_pass + cert/key presence to PasswordTls / Password / Tls / None in TryFrom
- Add parser and TryFrom tests

Closes #336 