### PR TITLE
feat: per-BSSID access points, security decode, and connect_to_bssid

### DIFF
--- a/nmrs/CHANGELOG.md
+++ b/nmrs/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the `nmrs` crate will be documented in this file.
 ## [Unreleased]
 ### Added
 - `nmrs::agent` module: NetworkManager secret agent for credential prompting over D-Bus (`SecretAgent`, `SecretAgentBuilder`, `SecretAgentHandle`, `SecretRequest`, `SecretResponder`, `SecretSetting`, `SecretAgentFlags`, `SecretAgentCapabilities`, `CancelReason`, `SecretStoreEvent`)
+- `AccessPoint` model preserving per-AP BSSID, frequency, security flags, and device state; `list_access_points(interface)` for full AP enumeration
+- `SecurityFeatures`, `ApMode`, `ConnectType` types for decoded NM security capabilities
+- `connect_to_bssid(ssid, bssid, creds)` for BSSID-targeted connections
+- `Network` gains `best_bssid`, `bssids`, `is_active`, `known`, and `security_features` fields
+- `ApBssidNotFound` and `InvalidBssid` error variants
 - Airplane-mode surface: `RadioState`, `AirplaneModeState`, `wifi_state()`, `wwan_state()`, `bluetooth_radio_state()`, `airplane_mode_state()`, `set_wireless_enabled()`, `set_wwan_enabled()`, `set_bluetooth_radio_enabled()`, `set_airplane_mode()`
 - Kernel rfkill awareness: hardware kill switch state via `/sys/class/rfkill`
 - `HardwareRadioKilled` and `BluezUnavailable` error variants

--- a/nmrs/Cargo.toml
+++ b/nmrs/Cargo.toml
@@ -51,3 +51,7 @@ path = "examples/secret_agent.rs"
 [[example]]
 name = "airplane_mode"
 path = "examples/airplane_mode.rs"
+
+[[example]]
+name = "ap_list"
+path = "examples/ap_list.rs"

--- a/nmrs/README.md
+++ b/nmrs/README.md
@@ -15,7 +15,7 @@ Rust bindings for NetworkManager via D-Bus.
 - **WiFi Management**: Connect to WPA-PSK, WPA-EAP, and open networks
 - **VPN Support**: WireGuard VPN connections with full configuration
 - **Ethernet**: Wired network connection management
-- **Network Discovery**: Scan and list available access points with signal strength
+- **Network Discovery**: Scan and list available access points with per-BSSID detail and security capabilities
 - **Profile Management**: Create, query, and delete saved connection profiles
 - **Real-Time Monitoring**: Signal-based network and device state change notifications
 - **Secret Agent**: Respond to NetworkManager credential prompts via an async stream API

--- a/nmrs/examples/ap_list.rs
+++ b/nmrs/examples/ap_list.rs
@@ -1,0 +1,22 @@
+use nmrs::NetworkManager;
+
+#[tokio::main]
+async fn main() -> nmrs::Result<()> {
+    let nm = NetworkManager::new().await?;
+    let mut aps = nm.list_access_points(None).await?;
+    aps.sort_by_key(|ap| std::cmp::Reverse(ap.strength));
+
+    for ap in &aps {
+        let active = if ap.is_active { "*" } else { " " };
+        println!(
+            "{active} {:>3}%  {:<24} {}  {} MHz  {:?}",
+            ap.strength,
+            ap.ssid,
+            ap.bssid,
+            ap.frequency_mhz,
+            ap.security.preferred_connect_type()
+        );
+    }
+
+    Ok(())
+}

--- a/nmrs/src/api/models/access_point.rs
+++ b/nmrs/src/api/models/access_point.rs
@@ -1,0 +1,410 @@
+//! Per-AP model preserving BSSID and per-device state.
+//!
+//! [`AccessPoint`] represents a single Wi-Fi access point seen by a specific
+//! wireless device, preserving the BSSID and all NM-reported properties.
+//! Use [`list_access_points`](crate::NetworkManager::list_access_points) to
+//! enumerate them; use [`list_networks`](crate::NetworkManager::list_networks)
+//! for the deduplicated SSID-grouped view.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use zvariant::OwnedObjectPath;
+
+use super::DeviceState;
+
+/// A single Wi-Fi access point reported by NetworkManager.
+///
+/// Unlike [`Network`](super::Network), which groups APs sharing an SSID,
+/// each `AccessPoint` corresponds to one BSSID and carries per-device state.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct AccessPoint {
+    /// D-Bus path of this access point object.
+    pub path: OwnedObjectPath,
+    /// D-Bus path of the wireless device that sees this AP.
+    pub device_path: OwnedObjectPath,
+    /// Interface name of the device (e.g. `"wlan0"`).
+    pub interface: String,
+    /// SSID decoded as UTF-8, or `"<hidden>"` for hidden networks.
+    pub ssid: String,
+    /// Raw SSID bytes for non-UTF-8 SSIDs.
+    pub ssid_bytes: Vec<u8>,
+    /// BSSID in `"XX:XX:XX:XX:XX:XX"` format.
+    pub bssid: String,
+    /// Operating frequency in MHz.
+    pub frequency_mhz: u32,
+    /// Maximum supported bitrate in Kbit/s.
+    pub max_bitrate_kbps: u32,
+    /// Signal strength percentage (0–100).
+    pub strength: u8,
+    /// AP operating mode.
+    pub mode: ApMode,
+    /// Decoded security capabilities.
+    pub security: SecurityFeatures,
+    /// Monotonic seconds since boot when last seen, or `None` if never.
+    pub last_seen_secs: Option<i64>,
+    /// `true` if this AP is the active connection on `device_path`.
+    pub is_active: bool,
+    /// State of the wireless device at enumeration time (not live).
+    pub device_state: DeviceState,
+}
+
+/// Wi-Fi access point operating mode.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+pub enum ApMode {
+    /// Ad-hoc (IBSS) network.
+    Adhoc,
+    /// Infrastructure (managed) mode — the most common.
+    Infrastructure,
+    /// Access point (hotspot) mode.
+    Ap,
+    /// Mesh mode.
+    Mesh,
+    /// Unknown or unrecognised NM mode value.
+    Unknown(u32),
+}
+
+impl From<u32> for ApMode {
+    fn from(value: u32) -> Self {
+        match value {
+            1 => Self::Adhoc,
+            2 => Self::Infrastructure,
+            3 => Self::Ap,
+            4 => Self::Mesh,
+            other => Self::Unknown(other),
+        }
+    }
+}
+
+impl fmt::Display for ApMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Adhoc => write!(f, "Ad-Hoc"),
+            Self::Infrastructure => write!(f, "Infrastructure"),
+            Self::Ap => write!(f, "AP"),
+            Self::Mesh => write!(f, "Mesh"),
+            Self::Unknown(v) => write!(f, "Unknown({v})"),
+        }
+    }
+}
+
+/// Decoded security capabilities of an access point.
+///
+/// Derived from NetworkManager's `Flags`, `WpaFlags`, and `RsnFlags` properties
+/// using the `NM80211ApFlags` and `NM80211ApSecurityFlags` bitmask values:
+///
+/// | Flag constant | Value | Field(s) |
+/// |---|---|---|
+/// | `NM_802_11_AP_FLAGS_PRIVACY` | `0x1` | `privacy` |
+/// | `NM_802_11_AP_FLAGS_WPS` | `0x2` | `wps` |
+/// | `PAIR_WEP40` | `0x1` | `wep40` |
+/// | `PAIR_WEP104` | `0x2` | `wep104` |
+/// | `PAIR_TKIP` | `0x4` | `tkip` |
+/// | `PAIR_CCMP` | `0x8` | `ccmp` |
+/// | `KEY_MGMT_PSK` | `0x100` | `psk` |
+/// | `KEY_MGMT_802_1X` | `0x200` | `eap` |
+/// | `KEY_MGMT_SAE` | `0x400` | `sae` |
+/// | `KEY_MGMT_OWE` | `0x800` | `owe` |
+/// | `KEY_MGMT_OWE_TM` | `0x1000` | `owe_transition_mode` |
+/// | `KEY_MGMT_EAP_SUITE_B_192` | `0x2000` | `eap_suite_b_192` |
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default, Serialize, Deserialize)]
+pub struct SecurityFeatures {
+    /// AP advertises privacy (WEP or higher).
+    pub privacy: bool,
+    /// WPS (Wi-Fi Protected Setup) is available.
+    pub wps: bool,
+
+    /// Pre-shared key authentication (WPA/WPA2-Personal).
+    pub psk: bool,
+    /// 802.1X / EAP authentication (WPA/WPA2-Enterprise).
+    pub eap: bool,
+    /// Simultaneous Authentication of Equals (WPA3-Personal).
+    pub sae: bool,
+    /// Opportunistic Wireless Encryption.
+    pub owe: bool,
+    /// OWE transition mode (mixed open + OWE).
+    pub owe_transition_mode: bool,
+    /// EAP Suite B 192-bit (WPA3-Enterprise 192-bit).
+    pub eap_suite_b_192: bool,
+
+    /// Pairwise WEP-40 cipher.
+    pub wep40: bool,
+    /// Pairwise WEP-104 cipher.
+    pub wep104: bool,
+    /// TKIP cipher.
+    pub tkip: bool,
+    /// CCMP (AES) cipher.
+    pub ccmp: bool,
+}
+
+impl SecurityFeatures {
+    /// Returns `true` if no security mechanism is advertised.
+    #[must_use]
+    pub fn is_open(&self) -> bool {
+        !self.privacy
+            && !self.psk
+            && !self.eap
+            && !self.sae
+            && !self.owe
+            && !self.owe_transition_mode
+            && !self.eap_suite_b_192
+            && !self.wep40
+            && !self.wep104
+    }
+
+    /// Returns `true` if enterprise authentication is available.
+    #[must_use]
+    pub fn is_enterprise(&self) -> bool {
+        self.eap || self.eap_suite_b_192
+    }
+
+    /// Returns `true` if WPA3 (SAE or OWE) is available.
+    #[must_use]
+    pub fn is_wpa3(&self) -> bool {
+        self.sae || self.owe
+    }
+
+    /// Returns the preferred connection type for this security profile.
+    #[must_use]
+    pub fn preferred_connect_type(&self) -> ConnectType {
+        if self.eap || self.eap_suite_b_192 {
+            ConnectType::Eap
+        } else if self.sae {
+            ConnectType::Sae
+        } else if self.owe || self.owe_transition_mode {
+            ConnectType::Owe
+        } else if self.psk {
+            ConnectType::Psk
+        } else {
+            ConnectType::Open
+        }
+    }
+}
+
+/// Preferred connection type derived from [`SecurityFeatures`].
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+pub enum ConnectType {
+    /// Open (no authentication).
+    Open,
+    /// Pre-shared key (WPA/WPA2-Personal).
+    Psk,
+    /// SAE (WPA3-Personal).
+    Sae,
+    /// 802.1X / EAP (Enterprise).
+    Eap,
+    /// Opportunistic Wireless Encryption.
+    Owe,
+}
+
+impl fmt::Display for ConnectType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Open => write!(f, "Open"),
+            Self::Psk => write!(f, "PSK"),
+            Self::Sae => write!(f, "SAE"),
+            Self::Eap => write!(f, "EAP"),
+            Self::Owe => write!(f, "OWE"),
+        }
+    }
+}
+
+// NM80211ApFlags
+const AP_FLAGS_PRIVACY: u32 = 0x1;
+const AP_FLAGS_WPS: u32 = 0x2;
+
+// NM80211ApSecurityFlags (applied to both WpaFlags and RsnFlags)
+const SEC_PAIR_WEP40: u32 = 0x1;
+const SEC_PAIR_WEP104: u32 = 0x2;
+const SEC_PAIR_TKIP: u32 = 0x4;
+const SEC_PAIR_CCMP: u32 = 0x8;
+const SEC_KEY_MGMT_PSK: u32 = 0x100;
+const SEC_KEY_MGMT_802_1X: u32 = 0x200;
+const SEC_KEY_MGMT_SAE: u32 = 0x400;
+const SEC_KEY_MGMT_OWE: u32 = 0x800;
+const SEC_KEY_MGMT_OWE_TM: u32 = 0x1000;
+const SEC_KEY_MGMT_EAP_SUITE_B_192: u32 = 0x2000;
+
+/// Decodes NM's AP flag triplet into a [`SecurityFeatures`].
+///
+/// `flags` is `NM80211ApFlags`, `wpa` and `rsn` are `NM80211ApSecurityFlags`
+/// from the `WpaFlags` and `RsnFlags` AP properties respectively.
+pub(crate) fn decode_security(flags: u32, wpa: u32, rsn: u32) -> SecurityFeatures {
+    let combined = wpa | rsn;
+    SecurityFeatures {
+        privacy: (flags & AP_FLAGS_PRIVACY) != 0,
+        wps: (flags & AP_FLAGS_WPS) != 0,
+        psk: (combined & SEC_KEY_MGMT_PSK) != 0,
+        eap: (combined & SEC_KEY_MGMT_802_1X) != 0,
+        sae: (combined & SEC_KEY_MGMT_SAE) != 0,
+        owe: (combined & SEC_KEY_MGMT_OWE) != 0,
+        owe_transition_mode: (combined & SEC_KEY_MGMT_OWE_TM) != 0,
+        eap_suite_b_192: (combined & SEC_KEY_MGMT_EAP_SUITE_B_192) != 0,
+        wep40: (combined & SEC_PAIR_WEP40) != 0,
+        wep104: (combined & SEC_PAIR_WEP104) != 0,
+        tkip: (combined & SEC_PAIR_TKIP) != 0,
+        ccmp: (combined & SEC_PAIR_CCMP) != 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_open_network() {
+        let sec = decode_security(0, 0, 0);
+        assert!(sec.is_open());
+        assert!(!sec.is_enterprise());
+        assert!(!sec.is_wpa3());
+        assert_eq!(sec.preferred_connect_type(), ConnectType::Open);
+    }
+
+    #[test]
+    fn decode_wep40() {
+        let sec = decode_security(AP_FLAGS_PRIVACY, SEC_PAIR_WEP40, 0);
+        assert!(!sec.is_open());
+        assert!(sec.privacy);
+        assert!(sec.wep40);
+        assert_eq!(sec.preferred_connect_type(), ConnectType::Open);
+    }
+
+    #[test]
+    fn decode_wep104() {
+        let sec = decode_security(AP_FLAGS_PRIVACY, SEC_PAIR_WEP104, 0);
+        assert!(sec.wep104);
+        assert!(sec.privacy);
+    }
+
+    #[test]
+    fn decode_wpa_tkip_psk() {
+        let sec = decode_security(AP_FLAGS_PRIVACY, SEC_PAIR_TKIP | SEC_KEY_MGMT_PSK, 0);
+        assert!(sec.psk);
+        assert!(sec.tkip);
+        assert!(!sec.ccmp);
+        assert_eq!(sec.preferred_connect_type(), ConnectType::Psk);
+    }
+
+    #[test]
+    fn decode_wpa2_ccmp_psk() {
+        let sec = decode_security(AP_FLAGS_PRIVACY, 0, SEC_PAIR_CCMP | SEC_KEY_MGMT_PSK);
+        assert!(sec.psk);
+        assert!(sec.ccmp);
+        assert!(!sec.tkip);
+        assert_eq!(sec.preferred_connect_type(), ConnectType::Psk);
+    }
+
+    #[test]
+    fn decode_wpa2_enterprise() {
+        let sec = decode_security(AP_FLAGS_PRIVACY, 0, SEC_PAIR_CCMP | SEC_KEY_MGMT_802_1X);
+        assert!(sec.eap);
+        assert!(sec.ccmp);
+        assert!(sec.is_enterprise());
+        assert_eq!(sec.preferred_connect_type(), ConnectType::Eap);
+    }
+
+    #[test]
+    fn decode_wpa3_sae() {
+        let sec = decode_security(AP_FLAGS_PRIVACY, 0, SEC_PAIR_CCMP | SEC_KEY_MGMT_SAE);
+        assert!(sec.sae);
+        assert!(sec.ccmp);
+        assert!(sec.is_wpa3());
+        assert_eq!(sec.preferred_connect_type(), ConnectType::Sae);
+    }
+
+    #[test]
+    fn decode_owe() {
+        let sec = decode_security(0, 0, SEC_PAIR_CCMP | SEC_KEY_MGMT_OWE);
+        assert!(sec.owe);
+        assert!(sec.is_wpa3());
+        assert_eq!(sec.preferred_connect_type(), ConnectType::Owe);
+    }
+
+    #[test]
+    fn decode_owe_transition() {
+        let sec = decode_security(0, 0, SEC_KEY_MGMT_OWE_TM);
+        assert!(sec.owe_transition_mode);
+        assert_eq!(sec.preferred_connect_type(), ConnectType::Owe);
+    }
+
+    #[test]
+    fn decode_eap_suite_b_192() {
+        let sec = decode_security(
+            AP_FLAGS_PRIVACY,
+            0,
+            SEC_PAIR_CCMP | SEC_KEY_MGMT_EAP_SUITE_B_192,
+        );
+        assert!(sec.eap_suite_b_192);
+        assert!(sec.is_enterprise());
+        assert_eq!(sec.preferred_connect_type(), ConnectType::Eap);
+    }
+
+    #[test]
+    fn decode_wps_flag() {
+        let sec = decode_security(AP_FLAGS_WPS, 0, 0);
+        assert!(sec.wps);
+    }
+
+    #[test]
+    fn decode_mixed_wpa_wpa2() {
+        let sec = decode_security(
+            AP_FLAGS_PRIVACY,
+            SEC_PAIR_TKIP | SEC_KEY_MGMT_PSK,
+            SEC_PAIR_CCMP | SEC_KEY_MGMT_PSK,
+        );
+        assert!(sec.psk);
+        assert!(sec.tkip);
+        assert!(sec.ccmp);
+    }
+
+    #[test]
+    fn ap_mode_from_u32() {
+        assert_eq!(ApMode::from(1), ApMode::Adhoc);
+        assert_eq!(ApMode::from(2), ApMode::Infrastructure);
+        assert_eq!(ApMode::from(3), ApMode::Ap);
+        assert_eq!(ApMode::from(4), ApMode::Mesh);
+        assert_eq!(ApMode::from(99), ApMode::Unknown(99));
+    }
+
+    #[test]
+    fn connect_type_display() {
+        assert_eq!(ConnectType::Open.to_string(), "Open");
+        assert_eq!(ConnectType::Psk.to_string(), "PSK");
+        assert_eq!(ConnectType::Sae.to_string(), "SAE");
+        assert_eq!(ConnectType::Eap.to_string(), "EAP");
+        assert_eq!(ConnectType::Owe.to_string(), "OWE");
+    }
+
+    #[test]
+    fn security_features_default_is_open() {
+        let sec = SecurityFeatures::default();
+        assert!(sec.is_open());
+    }
+
+    #[test]
+    fn eap_prioritized_over_psk() {
+        let sec = SecurityFeatures {
+            psk: true,
+            eap: true,
+            ccmp: true,
+            privacy: true,
+            ..Default::default()
+        };
+        assert_eq!(sec.preferred_connect_type(), ConnectType::Eap);
+    }
+
+    #[test]
+    fn sae_prioritized_over_psk() {
+        let sec = SecurityFeatures {
+            psk: true,
+            sae: true,
+            ccmp: true,
+            privacy: true,
+            ..Default::default()
+        };
+        assert_eq!(sec.preferred_connect_type(), ConnectType::Sae);
+    }
+}

--- a/nmrs/src/api/models/error.rs
+++ b/nmrs/src/api/models/error.rs
@@ -189,6 +189,19 @@ pub enum ConnectionError {
     #[error("error while parsing a configuration: {0}")]
     ParseError(OvpnParseError),
 
+    /// Access point with the given SSID and BSSID was not found.
+    #[error("access point for SSID '{ssid}' with BSSID '{bssid}' not found")]
+    ApBssidNotFound {
+        /// SSID that was searched for.
+        ssid: String,
+        /// BSSID that was searched for.
+        bssid: String,
+    },
+
+    /// Invalid BSSID format.
+    #[error("invalid BSSID format: '{0}' (expected XX:XX:XX:XX:XX:XX)")]
+    InvalidBssid(String),
+
     /// A radio is hardware-disabled via rfkill.
     #[error("radio is hardware-disabled (rfkill)")]
     HardwareRadioKilled,

--- a/nmrs/src/api/models/mod.rs
+++ b/nmrs/src/api/models/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod access_point;
 mod bluetooth;
 mod config;
 mod connection_state;
@@ -14,6 +15,7 @@ mod wireguard;
 #[path = "tests.rs"]
 mod tests;
 
+pub use access_point::*;
 pub use bluetooth::*;
 pub use config::*;
 pub use connection_state::*;

--- a/nmrs/src/api/models/wifi.rs
+++ b/nmrs/src/api/models/wifi.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use super::access_point::SecurityFeatures;
+
 /// Represents a Wi-Fi network discovered during a scan.
 ///
 /// This struct contains information about a WiFi network that was discovered
@@ -55,6 +57,21 @@ pub struct Network {
     pub ip4_address: Option<String>,
     /// Assigned IPv6 address with CIDR notation (only present when connected)
     pub ip6_address: Option<String>,
+    /// BSSID of the strongest AP for this SSID.
+    #[serde(default)]
+    pub best_bssid: String,
+    /// All known BSSIDs for this SSID, strongest first.
+    #[serde(default)]
+    pub bssids: Vec<String>,
+    /// `true` if this network is currently active (connected).
+    #[serde(default)]
+    pub is_active: bool,
+    /// `true` if a saved connection profile exists for this SSID.
+    #[serde(default)]
+    pub known: bool,
+    /// Decoded security capabilities from NM flag triplet.
+    #[serde(default)]
+    pub security_features: SecurityFeatures,
 }
 
 /// Detailed information about a Wi-Fi network.
@@ -618,16 +635,26 @@ impl Network {
     /// this method keeps the strongest signal and combines security flags.
     /// Used internally during network scanning to deduplicate results.
     pub fn merge_ap(&mut self, other: &Network) {
+        if let Some(ref b) = other.bssid
+            && !self.bssids.contains(b)
+        {
+            self.bssids.push(b.clone());
+        }
+
         if other.strength.unwrap_or(0) > self.strength.unwrap_or(0) {
             self.strength = other.strength;
             self.frequency = other.frequency;
             self.bssid = other.bssid.clone();
+            self.best_bssid = other.best_bssid.clone();
+            self.security_features = other.security_features;
         }
 
         self.secured |= other.secured;
         self.is_psk |= other.is_psk;
         self.is_eap |= other.is_eap;
         self.is_hotspot |= other.is_hotspot;
+        self.is_active |= other.is_active;
+        self.known |= other.known;
 
         if self.ip4_address.is_none() {
             self.ip4_address.clone_from(&other.ip4_address);
@@ -659,6 +686,11 @@ mod network_merge_tests {
             is_hotspot: false,
             ip4_address: Some("192.168.1.5/24".into()),
             ip6_address: Some("fe80::1/64".into()),
+            best_bssid: "aa:aa:aa:aa:aa:aa".into(),
+            bssids: vec!["aa:aa:aa:aa:aa:aa".into()],
+            is_active: true,
+            known: false,
+            security_features: Default::default(),
         };
         let stronger = Network {
             device: String::new(),
@@ -672,12 +704,20 @@ mod network_merge_tests {
             is_hotspot: false,
             ip4_address: None,
             ip6_address: None,
+            best_bssid: "bb:bb:bb:bb:bb:bb".into(),
+            bssids: vec!["bb:bb:bb:bb:bb:bb".into()],
+            is_active: false,
+            known: false,
+            security_features: Default::default(),
         };
         weaker_connected.merge_ap(&stronger);
         assert_eq!(weaker_connected.strength, Some(90));
         assert_eq!(weaker_connected.bssid, Some("bb:bb:bb:bb:bb:bb".into()));
+        assert_eq!(weaker_connected.best_bssid, "bb:bb:bb:bb:bb:bb");
         assert_eq!(weaker_connected.ip4_address, Some("192.168.1.5/24".into()));
         assert_eq!(weaker_connected.ip6_address, Some("fe80::1/64".into()));
         assert_eq!(weaker_connected.device, "wlan0");
+        assert!(weaker_connected.is_active);
+        assert_eq!(weaker_connected.bssids.len(), 2);
     }
 }

--- a/nmrs/src/api/network_manager.rs
+++ b/nmrs/src/api/network_manager.rs
@@ -4,14 +4,15 @@ use tokio::sync::watch;
 use zbus::Connection;
 
 use crate::Result;
+use crate::api::models::access_point::AccessPoint;
 use crate::api::models::{
     AirplaneModeState, Device, Network, NetworkInfo, RadioState, WifiSecurity,
 };
 use crate::core::airplane;
 use crate::core::bluetooth::connect_bluetooth;
 use crate::core::connection::{
-    connect, connect_wired, disconnect, forget_by_name_and_type, get_device_by_interface,
-    is_connected,
+    connect, connect_to_bssid, connect_wired, disconnect, forget_by_name_and_type,
+    get_device_by_interface, is_connected,
 };
 use crate::core::connection_settings::{
     get_saved_connection_path, has_saved_connection, list_saved_connections,
@@ -19,7 +20,7 @@ use crate::core::connection_settings::{
 use crate::core::device::{
     is_connecting, list_bluetooth_devices, list_devices, wait_for_wifi_ready,
 };
-use crate::core::scan::{current_network, list_networks, scan_networks};
+use crate::core::scan::{current_network, list_access_points, list_networks, scan_networks};
 use crate::core::vpn::{connect_vpn, disconnect_vpn, get_vpn_info, list_vpn_connections};
 use crate::models::{
     BluetoothDevice, BluetoothIdentity, VpnConfig, VpnConfiguration, VpnConnection,
@@ -222,8 +223,78 @@ impl NetworkManager {
     }
 
     /// Lists all visible Wi-Fi networks.
+    ///
+    /// Networks sharing an SSID on the same device are grouped, keeping the
+    /// strongest AP as the representative. Each returned [`Network`] carries
+    /// `best_bssid`, `bssids`, and `security_features` from the underlying APs.
     pub async fn list_networks(&self) -> Result<Vec<Network>> {
         list_networks(&self.conn).await
+    }
+
+    /// Lists all visible access points, one entry per BSSID.
+    ///
+    /// Unlike [`list_networks`](Self::list_networks), this preserves
+    /// duplicate BSSIDs for the same SSID and includes per-AP details
+    /// like BSSID, exact frequency, bitrate, and device state.
+    ///
+    /// Pass `interface` to restrict to a single wireless device (e.g.
+    /// `Some("wlan0")`), or `None` for all devices.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use nmrs::NetworkManager;
+    ///
+    /// # async fn example() -> nmrs::Result<()> {
+    /// let nm = NetworkManager::new().await?;
+    /// let mut aps = nm.list_access_points(None).await?;
+    /// aps.sort_by(|a, b| b.strength.cmp(&a.strength));
+    /// for ap in &aps {
+    ///     println!("{:>3}%  {:<20} {}  {} MHz",
+    ///         ap.strength, ap.ssid, ap.bssid, ap.frequency_mhz);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list_access_points(&self, interface: Option<&str>) -> Result<Vec<AccessPoint>> {
+        list_access_points(&self.conn, interface).await
+    }
+
+    /// Connects to a specific access point by SSID and optional BSSID.
+    ///
+    /// If `bssid` is `Some`, the connection targets that specific AP rather
+    /// than the strongest match for the SSID. If `None`, behaves identically
+    /// to [`connect`](Self::connect).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ApBssidNotFound`](crate::ConnectionError::ApBssidNotFound) if
+    /// no AP matching both the SSID and BSSID is visible.
+    /// Returns [`InvalidBssid`](crate::ConnectionError::InvalidBssid) if the
+    /// BSSID format is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use nmrs::{NetworkManager, WifiSecurity};
+    ///
+    /// # async fn example() -> nmrs::Result<()> {
+    /// let nm = NetworkManager::new().await?;
+    /// nm.connect_to_bssid(
+    ///     "HomeWiFi",
+    ///     Some("AA:BB:CC:DD:EE:FF"),
+    ///     WifiSecurity::WpaPsk { psk: "password".into() },
+    /// ).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn connect_to_bssid(
+        &self,
+        ssid: &str,
+        bssid: Option<&str>,
+        creds: WifiSecurity,
+    ) -> Result<()> {
+        connect_to_bssid(&self.conn, ssid, bssid, creds, Some(self.timeout_config)).await
     }
 
     /// Connects to a Wi-Fi network with the given credentials.

--- a/nmrs/src/core/connection.rs
+++ b/nmrs/src/core/connection.rs
@@ -15,7 +15,7 @@ use crate::monitoring::transport::ActiveTransport;
 use crate::monitoring::wifi::Wifi;
 use crate::types::constants::{device_state, device_type, timeouts};
 use crate::util::utils::{decode_ssid_or_empty, nm_proxy};
-use crate::util::validation::{validate_ssid, validate_wifi_security};
+use crate::util::validation::{validate_bssid, validate_ssid, validate_wifi_security};
 
 /// Decision on whether to reuse a saved connection or create a fresh one.
 enum SavedDecision {
@@ -530,6 +530,121 @@ async fn find_ap(
     }
 
     Err(ConnectionError::NotFound)
+}
+
+/// Finds an access point matching both SSID and BSSID.
+async fn find_ap_by_bssid(
+    conn: &Connection,
+    wifi: &NMWirelessProxy<'_>,
+    target_ssid: &str,
+    target_bssid: &str,
+) -> Result<OwnedObjectPath> {
+    let access_points = wifi.access_points().await?;
+
+    for ap_path in access_points {
+        let ap = NMAccessPointProxy::builder(conn)
+            .path(ap_path.clone())?
+            .build()
+            .await?;
+
+        let ssid_bytes = ap.ssid().await?;
+        let ssid = decode_ssid_or_empty(&ssid_bytes);
+
+        if ssid != target_ssid {
+            continue;
+        }
+
+        let bssid = ap.hw_address().await?;
+        if bssid.eq_ignore_ascii_case(target_bssid) {
+            return Ok(ap_path);
+        }
+    }
+
+    Err(ConnectionError::ApBssidNotFound {
+        ssid: target_ssid.to_string(),
+        bssid: target_bssid.to_string(),
+    })
+}
+
+/// Connects to a specific access point identified by SSID and optionally BSSID.
+///
+/// If `bssid` is `Some`, the connection targets that specific AP.
+/// If `None`, falls through to the existing best-match behavior.
+pub(crate) async fn connect_to_bssid(
+    conn: &Connection,
+    ssid: &str,
+    bssid: Option<&str>,
+    creds: WifiSecurity,
+    timeout_config: Option<TimeoutConfig>,
+) -> Result<()> {
+    if let Some(b) = bssid {
+        validate_bssid(b)?;
+    }
+
+    match bssid {
+        None => connect(conn, ssid, creds, timeout_config).await,
+        Some(target_bssid) => {
+            validate_ssid(ssid)?;
+            validate_wifi_security(&creds)?;
+
+            debug!(
+                "Connecting to '{}' BSSID={} | secured={} is_psk={} is_eap={}",
+                ssid,
+                target_bssid,
+                creds.secured(),
+                creds.is_psk(),
+                creds.is_eap()
+            );
+
+            let nm = NMProxy::new(conn).await?;
+            let saved_raw = get_saved_connection_path(conn, ssid).await?;
+            let decision = decide_saved_connection(saved_raw, &creds)?;
+            let wifi_device = find_wifi_device(conn, &nm).await?;
+            let wifi = NMWirelessProxy::builder(conn)
+                .path(wifi_device.clone())?
+                .build()
+                .await?;
+
+            match wifi.request_scan(HashMap::new()).await {
+                Ok(_) => debug!("Scan requested successfully"),
+                Err(e) => warn!("Scan request failed: {e}"),
+            }
+            futures_timer::Delay::new(timeouts::scan_wait()).await;
+
+            let specific_object = find_ap_by_bssid(conn, &wifi, ssid, target_bssid).await?;
+
+            match decision {
+                SavedDecision::UseSaved(saved) => {
+                    ensure_disconnected(conn, &nm, &wifi_device, timeout_config).await?;
+                    connect_via_saved(
+                        conn,
+                        &nm,
+                        &wifi_device,
+                        &specific_object,
+                        &creds,
+                        saved,
+                        timeout_config,
+                    )
+                    .await?;
+                }
+                SavedDecision::RebuildFresh => {
+                    build_and_activate_new(
+                        conn,
+                        &nm,
+                        &wifi_device,
+                        &specific_object,
+                        ssid,
+                        creds,
+                        timeout_config,
+                    )
+                    .await?;
+                }
+            }
+
+            info!("Successfully connected to '{ssid}' (BSSID: {target_bssid})");
+            Ok(())
+        }
+    }
 }
 
 /// Ensures the Wi-Fi device is disconnected before attempting a new connection.

--- a/nmrs/src/core/scan.rs
+++ b/nmrs/src/core/scan.rs
@@ -7,13 +7,14 @@ use std::collections::HashMap;
 use zbus::Connection;
 
 use crate::Result;
-use crate::api::models::{ConnectionError, Network};
+use crate::api::models::access_point::{AccessPoint, ApMode, decode_security};
+use crate::api::models::{ConnectionError, DeviceState, Network};
+use crate::core::connection_settings::has_saved_connection;
 use crate::dbus::{NMAccessPointProxy, NMDeviceProxy, NMProxy, NMWirelessProxy};
 use crate::monitoring::info::current_ssid;
 use crate::types::constants::{device_type, security_flags, wifi_mode};
 use crate::util::utils::{
-    decode_ssid_or_empty, decode_ssid_or_hidden, for_each_access_point,
-    get_ip_addresses_from_active_connection,
+    decode_ssid_or_empty, decode_ssid_or_hidden, get_ip_addresses_from_active_connection,
 };
 
 /// Triggers a Wi-Fi scan on all wireless devices.
@@ -62,72 +63,186 @@ pub(crate) async fn scan_networks(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
-/// Lists all visible Wi-Fi networks.
+/// Lists all visible access points, one entry per BSSID.
 ///
-/// Enumerates access points from all Wi-Fi devices and returns a deduplicated
-/// list of networks. Networks are keyed by (SSID, frequency) to distinguish
-/// 2.4GHz and 5GHz bands of the same network.
+/// When `interface` is `Some`, only APs from that wireless device are returned.
+/// When `None`, APs from all wireless devices are returned.
 ///
-/// When multiple access points share the same SSID and frequency (e.g., mesh
-/// networks), the one with the strongest signal is returned.
-///
-/// For the access point that matches the device's active connection, the result
-/// includes the interface name and assigned IPv4/IPv6 addresses (CIDR), consistent
-/// with `current_network`.
-pub(crate) async fn list_networks(conn: &Connection) -> Result<Vec<Network>> {
-    let mut networks: HashMap<(String, u32), Network> = HashMap::new();
+/// The returned list is ordered per-device then NM's native order (no explicit
+/// strength sort — consumers can sort as needed).
+pub(crate) async fn list_access_points(
+    conn: &Connection,
+    interface: Option<&str>,
+) -> Result<Vec<AccessPoint>> {
+    let nm = NMProxy::new(conn).await?;
+    let devices = nm.get_devices().await?;
 
-    let all_networks = for_each_access_point(conn, |_dev, active_ap, ap_path, ap, on_device| {
-        let is_this_ap = active_ap.as_str() != "/" && active_ap == &ap_path;
-        Box::pin(async move {
+    let mut results = Vec::new();
+
+    for dp in devices {
+        let dev = NMDeviceProxy::builder(conn)
+            .path(dp.clone())?
+            .build()
+            .await?;
+
+        if dev.device_type().await? != device_type::WIFI {
+            continue;
+        }
+
+        let iface = dev.interface().await.unwrap_or_default();
+
+        if let Some(target) = interface
+            && iface != target
+        {
+            continue;
+        }
+
+        let raw_state = dev.state().await?;
+        let device_state: DeviceState = raw_state.into();
+
+        let wifi = NMWirelessProxy::builder(conn)
+            .path(dp.clone())?
+            .build()
+            .await?;
+
+        let active_ap = wifi.active_access_point().await?;
+        let is_active_ap = |path: &zvariant::OwnedObjectPath| -> bool {
+            active_ap.as_str() != "/" && &active_ap == path
+        };
+
+        for ap_path in wifi.access_points().await? {
+            let ap = NMAccessPointProxy::builder(conn)
+                .path(ap_path.clone())?
+                .build()
+                .await?;
+
             let ssid_bytes = ap.ssid().await?;
             let ssid = decode_ssid_or_hidden(&ssid_bytes);
-            let strength = ap.strength().await?;
             let bssid = ap.hw_address().await?;
             let flags = ap.flags().await?;
             let wpa = ap.wpa_flags().await?;
             let rsn = ap.rsn_flags().await?;
-            let frequency = ap.frequency().await?;
-
-            let secured = (flags & security_flags::WEP) != 0 || wpa != 0 || rsn != 0;
-            let is_psk = (wpa & security_flags::PSK) != 0 || (rsn & security_flags::PSK) != 0;
-            let is_eap = (wpa & security_flags::EAP) != 0 || (rsn & security_flags::EAP) != 0;
-            let is_hotspot = ap.mode().await.unwrap_or(0) == wifi_mode::AP;
-
-            let (device, ip4_address, ip6_address) = if is_this_ap {
-                on_device
+            let frequency_mhz = ap.frequency().await?;
+            let max_bitrate_kbps = ap.max_bitrate().await.unwrap_or(0);
+            let strength = ap.strength().await?;
+            let mode_raw = ap.mode().await.unwrap_or(0);
+            let last_seen_raw = ap.last_seen().await.unwrap_or(-1);
+            let last_seen_secs = if last_seen_raw < 0 {
+                None
             } else {
-                (String::new(), None, None)
+                Some(i64::from(last_seen_raw))
             };
 
-            let network = Network {
-                device,
+            results.push(AccessPoint {
+                path: ap_path.clone(),
+                device_path: dp.clone(),
+                interface: iface.clone(),
                 ssid: ssid.to_string(),
-                bssid: Some(bssid),
-                strength: Some(strength),
-                frequency: Some(frequency),
-                secured,
-                is_psk,
-                is_eap,
-                is_hotspot,
-                ip4_address,
-                ip6_address,
-            };
-
-            Ok(Some((ssid, frequency, network)))
-        })
-    })
-    .await?;
-
-    // Deduplicate: use (SSID, frequency) as key, keep strongest signal
-    for (ssid, frequency, new_net) in all_networks {
-        networks
-            .entry((ssid.to_string(), frequency))
-            .and_modify(|n| n.merge_ap(&new_net))
-            .or_insert(new_net);
+                ssid_bytes: ssid_bytes.clone(),
+                bssid,
+                frequency_mhz,
+                max_bitrate_kbps,
+                strength,
+                mode: ApMode::from(mode_raw),
+                security: decode_security(flags, wpa, rsn),
+                last_seen_secs,
+                is_active: is_active_ap(&ap_path),
+                device_state: device_state.clone(),
+            });
+        }
     }
 
-    Ok(networks.into_values().collect())
+    Ok(results)
+}
+
+/// Lists all visible Wi-Fi networks.
+///
+/// Enumerates access points from all Wi-Fi devices and returns a deduplicated
+/// list of networks. Networks are keyed by (SSID, device interface) and groups
+/// APs by SSID, picking the strongest signal as the representative.
+///
+/// Each returned [`Network`] carries the `best_bssid`, `bssids` list, and
+/// `security_features` from the underlying access points.
+pub(crate) async fn list_networks(conn: &Connection) -> Result<Vec<Network>> {
+    let aps = list_access_points(conn, None).await?;
+
+    let mut groups: HashMap<(String, String), Network> = HashMap::new();
+
+    for ap in &aps {
+        let key = (ap.interface.clone(), ap.ssid.clone());
+        let sec_flags = ap.security;
+        let secured = !sec_flags.is_open();
+        let is_psk = sec_flags.psk;
+        let is_eap = sec_flags.eap || sec_flags.eap_suite_b_192;
+        let is_hotspot = ap.mode == ApMode::Ap;
+
+        let (ip4_address, ip6_address) = if ap.is_active {
+            active_ip_addresses(conn, &ap.device_path).await
+        } else {
+            (None, None)
+        };
+
+        let net = Network {
+            device: if ap.is_active {
+                ap.interface.clone()
+            } else {
+                String::new()
+            },
+            ssid: ap.ssid.clone(),
+            bssid: Some(ap.bssid.clone()),
+            strength: Some(ap.strength),
+            frequency: Some(ap.frequency_mhz),
+            secured,
+            is_psk,
+            is_eap,
+            is_hotspot,
+            ip4_address,
+            ip6_address,
+            best_bssid: ap.bssid.clone(),
+            bssids: vec![ap.bssid.clone()],
+            is_active: ap.is_active,
+            known: false,
+            security_features: sec_flags,
+        };
+
+        groups
+            .entry(key)
+            .and_modify(|n| n.merge_ap(&net))
+            .or_insert(net);
+    }
+
+    // Populate `known` by checking saved connections
+    for net in groups.values_mut() {
+        net.known = has_saved_connection(conn, &net.ssid).await.unwrap_or(false);
+        if net.device.is_empty()
+            && net.is_active
+            && let Some(ap) = aps.iter().find(|a| a.ssid == net.ssid && a.is_active)
+        {
+            net.device.clone_from(&ap.interface);
+        }
+    }
+
+    Ok(groups.into_values().collect())
+}
+
+/// Helper to get IP addresses from the active connection on a device.
+async fn active_ip_addresses(
+    conn: &Connection,
+    device_path: &zvariant::OwnedObjectPath,
+) -> (Option<String>, Option<String>) {
+    let builder = match NMDeviceProxy::builder(conn).path(device_path.clone()) {
+        Ok(b) => b,
+        Err(_) => return (None, None),
+    };
+    let dev = match builder.build().await {
+        Ok(d) => d,
+        Err(_) => return (None, None),
+    };
+
+    match dev.active_connection().await {
+        Ok(ac) if ac.as_str() != "/" => get_ip_addresses_from_active_connection(conn, &ac).await,
+        _ => (None, None),
+    }
 }
 
 /// Returns the full Network object for the currently connected WiFi network.
@@ -203,10 +318,12 @@ pub(crate) async fn current_network(conn: &Connection) -> Result<Option<Network>
             (None, None)
         };
 
+        let sec_features = decode_security(flags, wpa, rsn);
+
         return Ok(Some(Network {
             device: interface,
             ssid: ssid.to_string(),
-            bssid: Some(bssid),
+            bssid: Some(bssid.clone()),
             strength: Some(strength),
             frequency: Some(frequency),
             secured,
@@ -215,6 +332,11 @@ pub(crate) async fn current_network(conn: &Connection) -> Result<Option<Network>
             is_hotspot,
             ip4_address,
             ip6_address,
+            best_bssid: bssid.clone(),
+            bssids: vec![bssid],
+            is_active: true,
+            known: true,
+            security_features: sec_features,
         }));
     }
 

--- a/nmrs/src/dbus/access_point.rs
+++ b/nmrs/src/dbus/access_point.rs
@@ -43,7 +43,11 @@ pub trait NMAccessPoint {
     #[zbus(property)]
     fn max_bitrate(&self) -> Result<u32>;
 
-    /// Wi-Fi mode (1 = adhoc, 2 = infrastructure, 3 = AP).
+    /// Wi-Fi mode (1 = adhoc, 2 = infrastructure, 3 = AP, 4 = mesh).
     #[zbus(property)]
     fn mode(&self) -> Result<u32>;
+
+    /// Monotonic seconds since boot when this AP was last seen, or -1 if never.
+    #[zbus(property)]
+    fn last_seen(&self) -> Result<i32>;
 }

--- a/nmrs/src/lib.rs
+++ b/nmrs/src/lib.rs
@@ -347,13 +347,13 @@ pub mod models {
 // Re-export commonly used types at crate root for convenience
 #[allow(deprecated)]
 pub use api::models::{
-    ActiveConnectionState, AirplaneModeState, BluetoothDevice, BluetoothIdentity,
-    BluetoothNetworkRole, ConnectionError, ConnectionOptions, ConnectionStateReason, Device,
-    DeviceState, DeviceType, EapMethod, EapOptions, Network, NetworkInfo, OpenVpnAuthType,
-    OpenVpnCompression, OpenVpnConfig, OpenVpnProxy, Phase2, RadioState, StateReason,
-    TimeoutConfig, VpnConfig, VpnConfiguration, VpnConnection, VpnConnectionInfo, VpnCredentials,
-    VpnDetails, VpnRoute, VpnType, WifiSecurity, WireGuardConfig, WireGuardPeer,
-    connection_state_reason_to_error, reason_to_error,
+    AccessPoint, ActiveConnectionState, AirplaneModeState, ApMode, BluetoothDevice,
+    BluetoothIdentity, BluetoothNetworkRole, ConnectType, ConnectionError, ConnectionOptions,
+    ConnectionStateReason, Device, DeviceState, DeviceType, EapMethod, EapOptions, Network,
+    NetworkInfo, OpenVpnAuthType, OpenVpnCompression, OpenVpnConfig, OpenVpnProxy, Phase2,
+    RadioState, SecurityFeatures, StateReason, TimeoutConfig, VpnConfig, VpnConfiguration,
+    VpnConnection, VpnConnectionInfo, VpnCredentials, VpnDetails, VpnRoute, VpnType, WifiSecurity,
+    WireGuardConfig, WireGuardPeer, connection_state_reason_to_error, reason_to_error,
 };
 pub use api::network_manager::NetworkManager;
 

--- a/nmrs/src/util/validation.rs
+++ b/nmrs/src/util/validation.rs
@@ -716,6 +716,29 @@ pub fn validate_bluetooth_address(bdaddr: &str) -> Result<(), ConnectionError> {
     Ok(())
 }
 
+/// Validates a BSSID (MAC address) in `XX:XX:XX:XX:XX:XX` format.
+///
+/// Both uppercase and lowercase hex digits are accepted.
+///
+/// # Errors
+///
+/// Returns [`ConnectionError::InvalidBssid`] if the format is invalid.
+pub fn validate_bssid(bssid: &str) -> Result<(), ConnectionError> {
+    let parts: Vec<&str> = bssid.split(':').collect();
+
+    if parts.len() != 6 {
+        return Err(ConnectionError::InvalidBssid(bssid.to_string()));
+    }
+
+    for part in parts {
+        if part.len() != 2 || !part.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(ConnectionError::InvalidBssid(bssid.to_string()));
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1141,5 +1164,40 @@ mod tests {
         let config = base_openvpn_config();
         assert!(config.auth_type.is_none());
         assert!(validate_openvpn_config(&config).is_ok());
+    }
+
+    #[test]
+    fn test_validate_bssid_valid_uppercase() {
+        assert!(validate_bssid("AA:BB:CC:DD:EE:FF").is_ok());
+    }
+
+    #[test]
+    fn test_validate_bssid_valid_lowercase() {
+        assert!(validate_bssid("aa:bb:cc:dd:ee:ff").is_ok());
+    }
+
+    #[test]
+    fn test_validate_bssid_valid_mixed() {
+        assert!(validate_bssid("aA:Bb:cC:Dd:eE:fF").is_ok());
+    }
+
+    #[test]
+    fn test_validate_bssid_too_short() {
+        assert!(validate_bssid("AA:BB:CC:DD:EE").is_err());
+    }
+
+    #[test]
+    fn test_validate_bssid_empty() {
+        assert!(validate_bssid("").is_err());
+    }
+
+    #[test]
+    fn test_validate_bssid_unicode() {
+        assert!(validate_bssid("AA:BB:CC:DD:EE:ÀÀ").is_err());
+    }
+
+    #[test]
+    fn test_validate_bssid_invalid_segment() {
+        assert!(validate_bssid("GG:BB:CC:DD:EE:FF").is_err());
     }
 }


### PR DESCRIPTION
This PR adds a full per-AP model and BSSID-targeted Wi‑Fi so UIs can list every BSSID, show richer security, and pin connections to one AP.

- **`AccessPoint`** — one row per BSSID with device path, interface, SSID bytes, frequency, bitrate, strength, `ApMode`, `SecurityFeatures`, `last_seen_secs`, `is_active`, and snapshot **`DeviceState`**.
- **`list_access_points(interface)`** — optional interface filter; order is per-device then NM’s AP list (no global strength sort).
- **`Network`** — new **`best_bssid`**, **`bssids`**, **`is_active`**, **`known`**, **`security_features`**; **`list_networks`** is built on **`list_access_points`** and groups by (interface, SSID) with strongest AP as representative.
- **`connect_to_bssid(ssid, bssid, creds)`** — optional BSSID; validates format and returns **`ApBssidNotFound`** / **`InvalidBssid`** when appropriate.
- D-Bus: **`LastSeen`** on the AccessPoint proxy; **`decode_security`** + tests; **`validate_bssid`** + tests.
