### PR TITLE
feat: per-interface Wi-Fi scoping for multi-radio systems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "nmrs"
-version = "2.5.0"
+version = "3.0.0"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ uuid = { version = "1.23.1", features = ["v4", "v5"] }
 futures = "0.3.32"
 futures-timer = "3.0.3"
 base64 = "0.22.1"
-nmrs = { path = "nmrs", version = "2.2" }
+nmrs = { path = "nmrs", version = "3.0" }
 gtk = { version = "0.11.2", package = "gtk4" }
 glib = "0.22.5"
 dirs = "6.0.0"

--- a/nmrs-gui/src/ui/connect.rs
+++ b/nmrs-gui/src/ui/connect.rs
@@ -205,7 +205,7 @@ fn draw_connect_modal(
                 };
 
                 debug!("Calling nm.connect() for '{ssid}'");
-                match nm.connect(&ssid, creds).await {
+                match nm.connect(&ssid, None, creds).await {
                     Ok(_) => {
                         debug!("nm.connect() succeeded!");
                         status.set_text("✓ Connected!");

--- a/nmrs-gui/src/ui/header.rs
+++ b/nmrs-gui/src/ui/header.rs
@@ -310,7 +310,7 @@ pub async fn refresh_networks(
     wireless_header.set_margin_start(12);
     list_container.append(&wireless_header);
 
-    if let Err(err) = ctx.nm.scan_networks().await {
+    if let Err(err) = ctx.nm.scan_networks(None).await {
         ctx.status.set_text(&format!("Scan failed: {err}"));
         is_scanning.set(false);
         return;
@@ -318,7 +318,7 @@ pub async fn refresh_networks(
 
     let mut last_len = 0;
     for _ in 0..5 {
-        let nets = ctx.nm.list_networks().await.unwrap_or_default();
+        let nets = ctx.nm.list_networks(None).await.unwrap_or_default();
         if nets.len() == last_len && last_len > 0 {
             break;
         }
@@ -326,7 +326,7 @@ pub async fn refresh_networks(
         glib::timeout_future_seconds(1).await;
     }
 
-    match ctx.nm.list_networks().await {
+    match ctx.nm.list_networks(None).await {
         Ok(mut nets) => {
             let current_conn = ctx.nm.current_connection_info().await;
             let (current_ssid, current_band) = if let Some((ssid, freq)) = current_conn {
@@ -460,7 +460,7 @@ pub async fn refresh_networks_no_scan(
     wireless_header.set_margin_start(12);
     list_container.append(&wireless_header);
 
-    match ctx.nm.list_networks().await {
+    match ctx.nm.list_networks(None).await {
         Ok(mut nets) => {
             let current_conn = ctx.nm.current_connection_info().await;
             let (current_ssid, current_band) = if let Some((ssid, freq)) = current_conn {

--- a/nmrs-gui/src/ui/networks.rs
+++ b/nmrs-gui/src/ui/networks.rs
@@ -132,7 +132,7 @@ impl NetworkRowController {
                         status_c.set_text(&format!("Connecting to {}...", ssid_c));
                         window_c.set_sensitive(false);
                         let creds = WifiSecurity::WpaPsk { psk: "".into() };
-                        match nm_c.connect(&ssid_c, creds).await {
+                        match nm_c.connect(&ssid_c, None, creds).await {
                             Ok(_) => {
                                 status_c.set_text("");
                                 on_success_c();
@@ -153,7 +153,7 @@ impl NetworkRowController {
                     status_c.set_text(&format!("Connecting to {}...", ssid_c));
                     window_c.set_sensitive(false);
                     let creds = WifiSecurity::Open;
-                    match nm_c.connect(&ssid_c, creds).await {
+                    match nm_c.connect(&ssid_c, None, creds).await {
                         Ok(_) => {
                             status_c.set_text("");
                             on_success_c();

--- a/nmrs/CHANGELOG.md
+++ b/nmrs/CHANGELOG.md
@@ -6,16 +6,16 @@ All notable changes to the `nmrs` crate will be documented in this file.
 ### Added
 - `nmrs::agent` module: NetworkManager secret agent for credential prompting over D-Bus (`SecretAgent`, `SecretAgentBuilder`, `SecretAgentHandle`, `SecretRequest`, `SecretResponder`, `SecretSetting`, `SecretAgentFlags`, `SecretAgentCapabilities`, `CancelReason`, `SecretStoreEvent`)
 - `AccessPoint` model preserving per-AP BSSID, frequency, security flags, and device state; `list_access_points(interface)` for full AP enumeration
-- `SecurityFeatures`, `ApMode`, `ConnectType` types for decoded NM security capabilities
-- `connect_to_bssid(ssid, bssid, creds)` for BSSID-targeted connections
-- `Network` gains `best_bssid`, `bssids`, `is_active`, `known`, and `security_features` fields
-- `ApBssidNotFound` and `InvalidBssid` error variants
 - Airplane-mode surface: `RadioState`, `AirplaneModeState`, `wifi_state()`, `wwan_state()`, `bluetooth_radio_state()`, `airplane_mode_state()`, `set_wireless_enabled()`, `set_wwan_enabled()`, `set_bluetooth_radio_enabled()`, `set_airplane_mode()`
 - Kernel rfkill awareness: hardware kill switch state via `/sys/class/rfkill`
 - `HardwareRadioKilled` and `BluezUnavailable` error variants
+- Per-Wi-Fi-device scoping: `WifiDevice` model, `list_wifi_devices()`, `wifi_device_by_interface()`, `WifiScope` builder via `nm.wifi("wlan1")`, `set_wifi_enabled(interface, bool)` for per-radio enable/disable
+- `WifiInterfaceNotFound` and `NotAWifiDevice` error variants
 
 ### Changed
-- Deprecated `wifi_enabled()`, `set_wifi_enabled()`, and `wifi_hardware_enabled()` in favor of `wifi_state()` and `set_wireless_enabled()`
+- **Breaking (3.0):** `connect`, `connect_to_bssid`, `disconnect`, `scan_networks`, and `list_networks` now take an `interface: Option<&str>` parameter. Pass `None` to preserve previous behavior, or `Some("wlan1")` to scope to a specific Wi-Fi interface. For an ergonomic per-interface API, use `nm.wifi("wlan1")` to obtain a `WifiScope`.
+- **Breaking (3.0):** `set_wifi_enabled` now requires an `interface: &str` argument and toggles only that radio (via `Device.Autoconnect` + `Device.Disconnect()`). For the global wireless killswitch use `set_wireless_enabled(bool)`.
+- **Breaking (3.0):** Removed deprecated `wifi_enabled()`, `wifi_hardware_enabled()`, and the no-arg `set_wifi_enabled(bool)`. Use `wifi_state()` and `set_wireless_enabled()`.
 - `VpnConfig` trait and `WireGuardConfig`; `NetworkManager::connect_vpn` accepts `VpnConfig` implementors; `VpnCredentials` deprecated with compatibility bridges ([#303](https://github.com/cachebag/nmrs/pull/303))
 
 ### Changed

--- a/nmrs/Cargo.toml
+++ b/nmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nmrs"
-version = "2.5.0"
+version = "3.0.0"
 authors = ["Akrm Al-Hakimi <alhakimiakrmj@gmail.com>"]
 edition.workspace = true
 rust-version = "1.94.0"
@@ -55,3 +55,7 @@ path = "examples/airplane_mode.rs"
 [[example]]
 name = "ap_list"
 path = "examples/ap_list.rs"
+
+[[example]]
+name = "multi_wifi"
+path = "examples/multi_wifi.rs"

--- a/nmrs/README.md
+++ b/nmrs/README.md
@@ -16,6 +16,7 @@ Rust bindings for NetworkManager via D-Bus.
 - **VPN Support**: WireGuard VPN connections with full configuration
 - **Ethernet**: Wired network connection management
 - **Network Discovery**: Scan and list available access points with per-BSSID detail and security capabilities
+- **Per-Interface Scoping**: Target specific Wi-Fi radios on multi-NIC systems via `nm.wifi("wlan1")` or `Option<&str>` interface arguments
 - **Profile Management**: Create, query, and delete saved connection profiles
 - **Real-Time Monitoring**: Signal-based network and device state change notifications
 - **Secret Agent**: Respond to NetworkManager credential prompts via an async stream API
@@ -27,7 +28,7 @@ Rust bindings for NetworkManager via D-Bus.
 
 ```toml
 [dependencies]
-nmrs = "2.0.0"
+nmrs = "3.0.0"
 ```
 or
 ```bash
@@ -47,16 +48,21 @@ use nmrs::{NetworkManager, WifiSecurity};
 async fn main() -> nmrs::Result<()> {
     let nm = NetworkManager::new().await?;
     
-    // List networks
-    let networks = nm.list_networks().await?;
+    // List networks (None = all Wi-Fi devices, or pass Some("wlan1") to scope)
+    let networks = nm.list_networks(None).await?;
     for net in &networks {
         println!("{} - Signal: {}%", net.ssid, net.strength.unwrap_or(0));
     }
-    
-    // Connect to WPA-PSK network
-    nm.connect("MyNetwork", WifiSecurity::WpaPsk {
+
+    // Connect to a WPA-PSK network on the first Wi-Fi device
+    nm.connect("MyNetwork", None, WifiSecurity::WpaPsk {
         psk: "password".into()
     }).await?;
+
+    // Or scope every operation to a specific radio
+    let wlan1 = nm.wifi("wlan1");
+    wlan1.scan().await?;
+    wlan1.connect("Guest", WifiSecurity::Open).await?;
     
     // Check current connection
     if let Some(ssid) = nm.current_ssid().await {
@@ -117,7 +123,7 @@ use nmrs::{NetworkManager, WifiSecurity, EapOptions, EapMethod, Phase2};
 async fn main() -> nmrs::Result<()> {
     let nm = NetworkManager::new().await?;
     
-    nm.connect("CorpNetwork", WifiSecurity::WpaEap {
+    nm.connect("CorpNetwork", None, WifiSecurity::WpaEap {
         opts: EapOptions {
             identity: "user@company.com".into(),
             password: "password".into(),

--- a/nmrs/examples/custom_timeouts.rs
+++ b/nmrs/examples/custom_timeouts.rs
@@ -29,6 +29,7 @@ async fn main() -> nmrs::Result<()> {
     println!("\nConnecting to network...");
     nm.connect(
         "MyNetwork",
+        None,
         WifiSecurity::WpaPsk {
             psk: std::env::var("WIFI_PASSWORD").unwrap_or_else(|_| "password".to_string()),
         },

--- a/nmrs/examples/multi_wifi.rs
+++ b/nmrs/examples/multi_wifi.rs
@@ -1,0 +1,59 @@
+//! Per-Wi-Fi-device enumeration and scoped operations.
+//!
+//! Lists every Wi-Fi interface NetworkManager manages, then triggers a
+//! scan and prints the visible SSIDs on each radio independently.
+//! Useful on laptops with USB Wi-Fi dongles or docks with a second adapter.
+//!
+//! Run with: `cargo run --example multi_wifi`
+
+use nmrs::NetworkManager;
+
+#[tokio::main]
+async fn main() -> nmrs::Result<()> {
+    let nm = NetworkManager::new().await?;
+
+    let radios = nm.list_wifi_devices().await?;
+    if radios.is_empty() {
+        println!("No Wi-Fi devices found.");
+        return Ok(());
+    }
+
+    println!("Found {} Wi-Fi radio(s):", radios.len());
+    for r in &radios {
+        println!(
+            "  {:<10}  {}  state={:?}  active={}{}",
+            r.interface,
+            r.hw_address,
+            r.state,
+            r.is_active,
+            r.active_ssid
+                .as_ref()
+                .map(|s| format!("  ssid={s}"))
+                .unwrap_or_default(),
+        );
+    }
+
+    for r in &radios {
+        let scope = nm.wifi(&r.interface);
+        println!("\n[{}] scanning...", r.interface);
+
+        if let Err(e) = scope.scan().await {
+            eprintln!("[{}] scan failed: {e}", r.interface);
+            continue;
+        }
+        // Give NM a moment to populate scan results.
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+        let nets = scope.list_networks().await?;
+        for n in nets {
+            println!(
+                "  {:>3}%  {:<32}  ({} BSSIDs)",
+                n.strength.unwrap_or(0),
+                n.ssid,
+                n.bssids.len(),
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/nmrs/examples/wifi_enterprise.rs
+++ b/nmrs/examples/wifi_enterprise.rs
@@ -22,7 +22,7 @@ async fn main() -> nmrs::Result<()> {
     let security = WifiSecurity::WpaEap { opts: eap_opts };
 
     println!("Connecting to enterprise WiFi network...");
-    nm.connect("CorpNetwork", security).await?;
+    nm.connect("CorpNetwork", None, security).await?;
 
     println!("Successfully connected to enterprise WiFi!");
 

--- a/nmrs/examples/wifi_scan.rs
+++ b/nmrs/examples/wifi_scan.rs
@@ -6,9 +6,9 @@ async fn main() -> nmrs::Result<()> {
     let nm = NetworkManager::new().await?;
 
     println!("Scanning for WiFi networks...");
-    nm.scan_networks().await?;
+    nm.scan_networks(None).await?;
 
-    let networks = nm.list_networks().await?;
+    let networks = nm.list_networks(None).await?;
     for net in networks {
         println!("{:30} {}%", net.ssid, net.strength.unwrap_or(0));
     }

--- a/nmrs/src/api/mod.rs
+++ b/nmrs/src/api/mod.rs
@@ -5,3 +5,4 @@
 pub mod builders;
 pub mod models;
 pub mod network_manager;
+pub mod wifi_scope;

--- a/nmrs/src/api/models/device.rs
+++ b/nmrs/src/api/models/device.rs
@@ -1,5 +1,7 @@
 use std::fmt::{Display, Formatter};
 
+use zvariant::OwnedObjectPath;
+
 /// Represents a network device managed by NetworkManager.
 ///
 /// A device can be a WiFi adapter, Ethernet interface, or other network hardware.
@@ -57,6 +59,39 @@ pub struct Device {
     pub ip6_address: Option<String>,
     // Link speed in Mb/s (wired devices)
     // pub speed: Option<u32>,
+}
+
+/// A Wi-Fi device summary returned by
+/// [`list_wifi_devices`](crate::NetworkManager::list_wifi_devices).
+///
+/// Use this on multi-radio machines (laptops with USB dongles, docks with a
+/// second wireless adapter, etc.) to discover the available interfaces and
+/// pick one to scope subsequent operations to. Pair with
+/// [`NetworkManager::wifi`](crate::NetworkManager::wifi) for ergonomic
+/// per-interface calls.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct WifiDevice {
+    /// D-Bus object path of the device.
+    pub path: OwnedObjectPath,
+    /// Interface name (e.g. `"wlan0"`).
+    pub interface: String,
+    /// Current MAC address (may be randomized).
+    pub hw_address: String,
+    /// Permanent (factory-burned) MAC, if NM exposes it.
+    pub permanent_hw_address: Option<String>,
+    /// Kernel driver name, if available.
+    pub driver: Option<String>,
+    /// Current device state.
+    pub state: DeviceState,
+    /// Whether NetworkManager manages this device.
+    pub managed: bool,
+    /// Whether NM will autoconnect known networks on this device.
+    pub autoconnect: bool,
+    /// `true` if the device currently has an active access point.
+    pub is_active: bool,
+    /// SSID of the currently active AP, if any.
+    pub active_ssid: Option<String>,
 }
 
 /// Represents the hardware identity of a network device.

--- a/nmrs/src/api/models/error.rs
+++ b/nmrs/src/api/models/error.rs
@@ -20,7 +20,7 @@ use super::state_reason::StateReason;
 /// # async fn example() -> nmrs::Result<()> {
 /// let nm = NetworkManager::new().await?;
 ///
-/// match nm.connect("MyNetwork", WifiSecurity::WpaPsk {
+/// match nm.connect("MyNetwork", None, WifiSecurity::WpaPsk {
 ///     psk: "password".into()
 /// }).await {
 ///     Ok(_) => println!("Connected!"),
@@ -48,7 +48,7 @@ use super::state_reason::StateReason;
 /// let nm = NetworkManager::new().await?;
 ///
 /// for attempt in 1..=3 {
-///     match nm.connect("MyNetwork", WifiSecurity::Open).await {
+///     match nm.connect("MyNetwork", None, WifiSecurity::Open).await {
 ///         Ok(_) => {
 ///             println!("Connected on attempt {}", attempt);
 ///             break;
@@ -201,6 +201,20 @@ pub enum ConnectionError {
     /// Invalid BSSID format.
     #[error("invalid BSSID format: '{0}' (expected XX:XX:XX:XX:XX:XX)")]
     InvalidBssid(String),
+
+    /// Interface exists but is not a Wi-Fi device.
+    #[error("interface '{interface}' is not a Wi-Fi device")]
+    NotAWifiDevice {
+        /// The interface name that was checked.
+        interface: String,
+    },
+
+    /// No Wi-Fi device with the given interface name.
+    #[error("no Wi-Fi device named '{interface}'")]
+    WifiInterfaceNotFound {
+        /// The interface name that was searched for.
+        interface: String,
+    },
 
     /// A radio is hardware-disabled via rfkill.
     #[error("radio is hardware-disabled (rfkill)")]

--- a/nmrs/src/api/models/wifi.rs
+++ b/nmrs/src/api/models/wifi.rs
@@ -15,9 +15,9 @@ use super::access_point::SecurityFeatures;
 /// # async fn example() -> nmrs::Result<()> {
 /// let nm = NetworkManager::new().await?;
 ///
-/// // Scan for networks
-/// nm.scan_networks().await?;
-/// let networks = nm.list_networks().await?;
+/// // Scan for networks (None = all Wi-Fi devices)
+/// nm.scan_networks(None).await?;
+/// let networks = nm.list_networks(None).await?;
 ///
 /// for net in networks {
 ///     println!("SSID: {}", net.ssid);
@@ -86,7 +86,7 @@ pub struct Network {
 ///
 /// # async fn example() -> nmrs::Result<()> {
 /// let nm = NetworkManager::new().await?;
-/// let networks = nm.list_networks().await?;
+/// let networks = nm.list_networks(None).await?;
 ///
 /// if let Some(network) = networks.first() {
 ///     let info = nm.show_details(network).await?;
@@ -564,7 +564,7 @@ impl EapOptionsBuilder {
 /// # async fn example() -> nmrs::Result<()> {
 /// let nm = NetworkManager::new().await?;
 ///
-/// nm.connect("HomeWiFi", WifiSecurity::WpaPsk {
+/// nm.connect("HomeWiFi", None, WifiSecurity::WpaPsk {
 ///     psk: "my_secure_password".into()
 /// }).await?;
 /// # Ok(())
@@ -585,7 +585,7 @@ impl EapOptionsBuilder {
 ///     .with_method(EapMethod::Peap)
 ///     .with_phase2(Phase2::Mschapv2);
 ///
-/// nm.connect("CorpWiFi", WifiSecurity::WpaEap {
+/// nm.connect("CorpWiFi", None, WifiSecurity::WpaEap {
 ///     opts: eap_opts
 /// }).await?;
 /// # Ok(())

--- a/nmrs/src/api/network_manager.rs
+++ b/nmrs/src/api/network_manager.rs
@@ -1,13 +1,12 @@
-#![allow(deprecated)]
-
 use tokio::sync::watch;
 use zbus::Connection;
 
 use crate::Result;
 use crate::api::models::access_point::AccessPoint;
 use crate::api::models::{
-    AirplaneModeState, Device, Network, NetworkInfo, RadioState, WifiSecurity,
+    AirplaneModeState, Device, Network, NetworkInfo, RadioState, WifiDevice, WifiSecurity,
 };
+use crate::api::wifi_scope::WifiScope;
 use crate::core::airplane;
 use crate::core::bluetooth::connect_bluetooth;
 use crate::core::connection::{
@@ -22,6 +21,7 @@ use crate::core::device::{
 };
 use crate::core::scan::{current_network, list_access_points, list_networks, scan_networks};
 use crate::core::vpn::{connect_vpn, disconnect_vpn, get_vpn_info, list_vpn_connections};
+use crate::core::wifi_device::{list_wifi_devices, set_wifi_enabled_for_interface};
 use crate::models::{
     BluetoothDevice, BluetoothIdentity, VpnConfig, VpnConfiguration, VpnConnection,
     VpnConnectionInfo,
@@ -66,14 +66,14 @@ use crate::types::constants::device_type;
 /// # async fn example() -> nmrs::Result<()> {
 /// let nm = NetworkManager::new().await?;
 ///
-/// // Scan and list networks
-/// let networks = nm.list_networks().await?;
+/// // Scan and list networks (None = all Wi-Fi devices)
+/// let networks = nm.list_networks(None).await?;
 /// for net in &networks {
 ///     println!("{}: {}%", net.ssid, net.strength.unwrap_or(0));
 /// }
 ///
-/// // Connect to a network
-/// nm.connect("MyNetwork", WifiSecurity::WpaPsk {
+/// // Connect to a network on the first Wi-Fi device
+/// nm.connect("MyNetwork", None, WifiSecurity::WpaPsk {
 ///     psk: "password".into()
 /// }).await?;
 /// # Ok(())
@@ -227,8 +227,67 @@ impl NetworkManager {
     /// Networks sharing an SSID on the same device are grouped, keeping the
     /// strongest AP as the representative. Each returned [`Network`] carries
     /// `best_bssid`, `bssids`, and `security_features` from the underlying APs.
-    pub async fn list_networks(&self) -> Result<Vec<Network>> {
-        list_networks(&self.conn).await
+    ///
+    /// Pass `interface = Some("wlan0")` to scope to a single Wi-Fi device,
+    /// or `None` to enumerate across every Wi-Fi device.
+    ///
+    /// **3.0 break:** added the `interface` parameter. For old behavior,
+    /// pass `None`.
+    pub async fn list_networks(&self, interface: Option<&str>) -> Result<Vec<Network>> {
+        list_networks(&self.conn, interface).await
+    }
+
+    /// Lists every managed Wi-Fi device on the system.
+    ///
+    /// Each [`WifiDevice`] includes its interface name, MAC, current state,
+    /// and the SSID of any active connection.
+    pub async fn list_wifi_devices(&self) -> Result<Vec<WifiDevice>> {
+        list_wifi_devices(&self.conn).await
+    }
+
+    /// Look up a single Wi-Fi device by interface name.
+    ///
+    /// Returns
+    /// [`WifiInterfaceNotFound`](crate::ConnectionError::WifiInterfaceNotFound)
+    /// if no device matches, or
+    /// [`NotAWifiDevice`](crate::ConnectionError::NotAWifiDevice) if the
+    /// interface exists but isn't a Wi-Fi device.
+    pub async fn wifi_device_by_interface(&self, name: &str) -> Result<WifiDevice> {
+        let all = list_wifi_devices(&self.conn).await?;
+        all.into_iter()
+            .find(|d| d.interface == name)
+            .ok_or_else(|| crate::ConnectionError::WifiInterfaceNotFound {
+                interface: name.to_string(),
+            })
+    }
+
+    /// Build a [`WifiScope`] pinned to the given interface.
+    ///
+    /// All operations on the returned scope target only that one Wi-Fi
+    /// device. Useful on multi-radio systems (laptops with USB dongles,
+    /// docks with a second wireless adapter).
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use nmrs::{NetworkManager, WifiSecurity};
+    ///
+    /// # async fn example() -> nmrs::Result<()> {
+    /// let nm = NetworkManager::new().await?;
+    /// nm.wifi("wlan1").connect(
+    ///     "Guest",
+    ///     WifiSecurity::WpaPsk { psk: "guestpass".into() },
+    /// ).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn wifi(&self, interface: impl Into<String>) -> WifiScope {
+        WifiScope {
+            conn: self.conn.clone(),
+            interface: interface.into(),
+            timeout_config: self.timeout_config,
+        }
     }
 
     /// Lists all visible access points, one entry per BSSID.
@@ -266,12 +325,22 @@ impl NetworkManager {
     /// than the strongest match for the SSID. If `None`, behaves identically
     /// to [`connect`](Self::connect).
     ///
+    /// **3.0 break:** added the `interface` parameter (3rd argument). Pass
+    /// `None` for the previous behavior of using the first available Wi-Fi
+    /// device, or `Some("wlan1")` to pin the connection to a specific
+    /// interface. For an ergonomic per-interface API, see
+    /// [`wifi`](Self::wifi).
+    ///
     /// # Errors
     ///
     /// Returns [`ApBssidNotFound`](crate::ConnectionError::ApBssidNotFound) if
     /// no AP matching both the SSID and BSSID is visible.
     /// Returns [`InvalidBssid`](crate::ConnectionError::InvalidBssid) if the
     /// BSSID format is invalid.
+    /// Returns
+    /// [`WifiInterfaceNotFound`](crate::ConnectionError::WifiInterfaceNotFound)
+    /// or [`NotAWifiDevice`](crate::ConnectionError::NotAWifiDevice) if the
+    /// supplied interface name is bad.
     ///
     /// # Examples
     ///
@@ -283,6 +352,7 @@ impl NetworkManager {
     /// nm.connect_to_bssid(
     ///     "HomeWiFi",
     ///     Some("AA:BB:CC:DD:EE:FF"),
+    ///     None,
     ///     WifiSecurity::WpaPsk { psk: "password".into() },
     /// ).await?;
     /// # Ok(())
@@ -292,20 +362,46 @@ impl NetworkManager {
         &self,
         ssid: &str,
         bssid: Option<&str>,
+        interface: Option<&str>,
         creds: WifiSecurity,
     ) -> Result<()> {
-        connect_to_bssid(&self.conn, ssid, bssid, creds, Some(self.timeout_config)).await
+        connect_to_bssid(
+            &self.conn,
+            ssid,
+            bssid,
+            creds,
+            interface,
+            Some(self.timeout_config),
+        )
+        .await
     }
 
     /// Connects to a Wi-Fi network with the given credentials.
+    ///
+    /// **3.0 break:** added the `interface` parameter (3rd argument). Pass
+    /// `None` for the previous behavior of using the first available Wi-Fi
+    /// device, or `Some("wlan1")` to pin the connection to a specific
+    /// interface.
     ///
     /// # Errors
     ///
     /// Returns `ConnectionError::NotFound` if the network is not visible,
     /// `ConnectionError::AuthFailed` if authentication fails, or other
     /// variants for specific failure reasons.
-    pub async fn connect(&self, ssid: &str, creds: WifiSecurity) -> Result<()> {
-        connect(&self.conn, ssid, creds, Some(self.timeout_config)).await
+    pub async fn connect(
+        &self,
+        ssid: &str,
+        interface: Option<&str>,
+        creds: WifiSecurity,
+    ) -> Result<()> {
+        connect(
+            &self.conn,
+            ssid,
+            creds,
+            interface,
+            Some(self.timeout_config),
+        )
+        .await
     }
 
     /// Connects to a wired (Ethernet) device.
@@ -632,22 +728,22 @@ impl NetworkManager {
         airplane::set_airplane_mode(&self.conn, enabled).await
     }
 
-    /// Returns whether Wi-Fi is currently enabled.
-    #[deprecated(since = "2.5.0", note = "use `wifi_state()` instead")]
-    pub async fn wifi_enabled(&self) -> Result<bool> {
-        Ok(self.wifi_state().await?.enabled)
-    }
-
-    /// Enables or disables Wi-Fi.
-    #[deprecated(since = "2.5.0", note = "use `set_wireless_enabled()` instead")]
-    pub async fn set_wifi_enabled(&self, value: bool) -> Result<()> {
-        self.set_wireless_enabled(value).await
-    }
-
-    /// Returns whether wireless hardware is currently enabled.
-    #[deprecated(since = "2.5.0", note = "use `wifi_state()` instead")]
-    pub async fn wifi_hardware_enabled(&self) -> Result<bool> {
-        Ok(self.wifi_state().await?.hardware_enabled)
+    /// Disable or re-enable a single Wi-Fi interface.
+    ///
+    /// Sets `Device.Autoconnect = enabled` and, when disabling, calls
+    /// `Device.Disconnect()`. This is independent of the global wireless
+    /// killswitch ([`set_wireless_enabled`](Self::set_wireless_enabled)) and
+    /// safe to use on multi-radio systems.
+    ///
+    /// # Errors
+    ///
+    /// Returns
+    /// [`WifiInterfaceNotFound`](crate::ConnectionError::WifiInterfaceNotFound)
+    /// if no device with that name exists, or
+    /// [`NotAWifiDevice`](crate::ConnectionError::NotAWifiDevice) if the
+    /// interface isn't a Wi-Fi device.
+    pub async fn set_wifi_enabled(&self, interface: &str, enabled: bool) -> Result<()> {
+        set_wifi_enabled_for_interface(&self.conn, interface, enabled).await
     }
 
     /// Waits for a Wi-Fi device to become ready (disconnected or activated).
@@ -655,9 +751,13 @@ impl NetworkManager {
         wait_for_wifi_ready(&self.conn).await
     }
 
-    /// Triggers a Wi-Fi scan on all wireless devices.
-    pub async fn scan_networks(&self) -> Result<()> {
-        scan_networks(&self.conn).await
+    /// Triggers a Wi-Fi scan.
+    ///
+    /// **3.0 break:** added the `interface` parameter. Pass `None` to scan
+    /// every Wi-Fi device, or `Some("wlan0")` to scan one. See
+    /// [`wifi`](Self::wifi) for an ergonomic per-interface API.
+    pub async fn scan_networks(&self, interface: Option<&str>) -> Result<()> {
+        scan_networks(&self.conn, interface).await
     }
 
     /// Returns whether any network device is currently in a transitional state.
@@ -691,12 +791,18 @@ impl NetworkManager {
         is_connected(&self.conn, ssid).await
     }
 
-    /// Disconnects from the current network.
+    /// Disconnects from the current Wi-Fi network.
     ///
-    /// If currently connected to a WiFi network, this will deactivate
-    /// the connection and wait for the device to reach disconnected state.
+    /// If currently connected to a Wi-Fi network, this deactivates the
+    /// active connection on the targeted device and waits for it to reach
+    /// the disconnected state.
     ///
-    /// Returns `Ok(())` if disconnected successfully or if no active connection exists.
+    /// **3.0 break:** added the `interface` parameter. Pass `None` for the
+    /// previous behavior (first Wi-Fi device), or `Some("wlan1")` to target
+    /// a specific interface.
+    ///
+    /// Returns `Ok(())` if disconnected successfully or if no active
+    /// connection exists.
     ///
     /// # Example
     ///
@@ -705,12 +811,13 @@ impl NetworkManager {
     ///
     /// # async fn example() -> nmrs::Result<()> {
     /// let nm = NetworkManager::new().await?;
-    /// nm.disconnect().await?;
+    /// nm.disconnect(None).await?;
+    /// nm.disconnect(Some("wlan1")).await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn disconnect(&self) -> Result<()> {
-        disconnect(&self.conn, Some(self.timeout_config)).await
+    pub async fn disconnect(&self, interface: Option<&str>) -> Result<()> {
+        disconnect(&self.conn, interface, Some(self.timeout_config)).await
     }
 
     /// Returns the full `Network` object for the currently connected WiFi network.

--- a/nmrs/src/api/wifi_scope.rs
+++ b/nmrs/src/api/wifi_scope.rs
@@ -1,0 +1,120 @@
+//! Per-Wi-Fi-device scoped operations.
+//!
+//! [`WifiScope`] is a lightweight, ergonomic wrapper around
+//! [`NetworkManager`](crate::NetworkManager) that pins every operation to a
+//! single Wi-Fi interface. Build it with
+//! [`NetworkManager::wifi`](crate::NetworkManager::wifi):
+//!
+//! ```no_run
+//! use nmrs::{NetworkManager, WifiSecurity};
+//!
+//! # async fn example() -> nmrs::Result<()> {
+//! let nm = NetworkManager::new().await?;
+//! let wlan1 = nm.wifi("wlan1");
+//!
+//! wlan1.scan().await?;
+//! let networks = wlan1.list_networks().await?;
+//! wlan1.connect("Guest", WifiSecurity::Open).await?;
+//! # Ok(())
+//! # }
+//! ```
+
+use crate::Result;
+use crate::api::models::access_point::AccessPoint;
+use crate::api::models::{Network, WifiSecurity};
+use crate::core::connection::{connect, connect_to_bssid, disconnect, forget_by_name_and_type};
+use crate::core::scan::{list_access_points, list_networks, scan_networks};
+use crate::core::wifi_device::set_wifi_enabled_for_interface;
+use crate::types::constants::device_type;
+
+/// Operations scoped to a single Wi-Fi interface.
+///
+/// Created via [`NetworkManager::wifi`](crate::NetworkManager::wifi).
+/// Cheap to construct (`Clone` is fine).
+#[derive(Debug, Clone)]
+pub struct WifiScope {
+    pub(crate) conn: zbus::Connection,
+    pub(crate) interface: String,
+    pub(crate) timeout_config: crate::api::models::TimeoutConfig,
+}
+
+impl WifiScope {
+    /// The interface name this scope is pinned to (e.g. `"wlan0"`).
+    #[must_use]
+    pub fn interface(&self) -> &str {
+        &self.interface
+    }
+
+    /// Trigger a Wi-Fi scan on this interface only.
+    pub async fn scan(&self) -> Result<()> {
+        scan_networks(&self.conn, Some(&self.interface)).await
+    }
+
+    /// List visible networks on this interface (grouped by SSID).
+    pub async fn list_networks(&self) -> Result<Vec<Network>> {
+        list_networks(&self.conn, Some(&self.interface)).await
+    }
+
+    /// List individual access points on this interface (one per BSSID).
+    pub async fn list_access_points(&self) -> Result<Vec<AccessPoint>> {
+        list_access_points(&self.conn, Some(&self.interface)).await
+    }
+
+    /// Connect this interface to the given SSID.
+    pub async fn connect(&self, ssid: &str, creds: WifiSecurity) -> Result<()> {
+        connect(
+            &self.conn,
+            ssid,
+            creds,
+            Some(&self.interface),
+            Some(self.timeout_config),
+        )
+        .await
+    }
+
+    /// Connect this interface to a specific BSSID for the given SSID.
+    pub async fn connect_to_bssid(
+        &self,
+        ssid: &str,
+        bssid: Option<&str>,
+        creds: WifiSecurity,
+    ) -> Result<()> {
+        connect_to_bssid(
+            &self.conn,
+            ssid,
+            bssid,
+            creds,
+            Some(&self.interface),
+            Some(self.timeout_config),
+        )
+        .await
+    }
+
+    /// Disconnect this interface from its active network, if any.
+    pub async fn disconnect(&self) -> Result<()> {
+        disconnect(&self.conn, Some(&self.interface), Some(self.timeout_config)).await
+    }
+
+    /// Enable or disable autoconnect on this interface only.
+    ///
+    /// Independent of NetworkManager's global Wi-Fi killswitch
+    /// ([`set_wireless_enabled`](crate::NetworkManager::set_wireless_enabled)).
+    pub async fn set_enabled(&self, enabled: bool) -> Result<()> {
+        set_wifi_enabled_for_interface(&self.conn, &self.interface, enabled).await
+    }
+
+    /// Forget a saved Wi-Fi connection by SSID.
+    ///
+    /// Note: NetworkManager keys profiles by SSID, not by interface, so this
+    /// forgets the profile globally — but is exposed here for ergonomic use
+    /// alongside the other per-scope operations.
+    pub async fn forget(&self, ssid: &str) -> Result<()> {
+        forget_by_name_and_type(
+            &self.conn,
+            ssid,
+            Some(device_type::WIFI),
+            Some(self.timeout_config),
+        )
+        .await
+    }
+}

--- a/nmrs/src/core/connection.rs
+++ b/nmrs/src/core/connection.rs
@@ -40,6 +40,7 @@ pub(crate) async fn connect(
     conn: &Connection,
     ssid: &str,
     creds: WifiSecurity,
+    interface: Option<&str>,
     timeout_config: Option<TimeoutConfig>,
 ) -> Result<()> {
     // Validate inputs before attempting connection
@@ -47,8 +48,9 @@ pub(crate) async fn connect(
     validate_wifi_security(&creds)?;
 
     debug!(
-        "Connecting to '{}' | secured={} is_psk={} is_eap={}",
+        "Connecting to '{}' on {:?} | secured={} is_psk={} is_eap={}",
         ssid,
+        interface,
         creds.secured(),
         creds.is_psk(),
         creds.is_eap()
@@ -59,8 +61,8 @@ pub(crate) async fn connect(
     let saved_raw = get_saved_connection_path(conn, ssid).await?;
     let decision = decide_saved_connection(saved_raw, &creds)?;
 
-    let wifi_device = find_wifi_device(conn, &nm).await?;
-    debug!("Found WiFi device: {}", wifi_device.as_str());
+    let wifi_device = resolve_wifi_device(conn, &nm, interface).await?;
+    debug!("Resolved WiFi device: {}", wifi_device.as_str());
 
     let wifi = NMWirelessProxy::builder(conn)
         .path(wifi_device.clone())?
@@ -503,6 +505,45 @@ async fn find_wifi_device(conn: &Connection, nm: &NMProxy<'_>) -> Result<OwnedOb
     find_device_by_type(conn, nm, device_type::WIFI).await
 }
 
+/// Resolves a Wi-Fi device path from an optional interface name.
+///
+/// `None` returns the first Wi-Fi device NM reports (back-compat behavior).
+/// `Some(name)` looks up the device by interface and verifies it is Wi-Fi:
+/// returns [`WifiInterfaceNotFound`] or [`NotAWifiDevice`] if not.
+///
+/// [`WifiInterfaceNotFound`]: ConnectionError::WifiInterfaceNotFound
+/// [`NotAWifiDevice`]: ConnectionError::NotAWifiDevice
+pub(crate) async fn resolve_wifi_device(
+    conn: &Connection,
+    nm: &NMProxy<'_>,
+    interface: Option<&str>,
+) -> Result<OwnedObjectPath> {
+    match interface {
+        None => find_wifi_device(conn, nm).await,
+        Some(name) => {
+            let path = match get_device_by_interface(conn, name).await {
+                Ok(p) => p,
+                Err(ConnectionError::NotFound) => {
+                    return Err(ConnectionError::WifiInterfaceNotFound {
+                        interface: name.to_string(),
+                    });
+                }
+                Err(e) => return Err(e),
+            };
+            let dev = NMDeviceProxy::builder(conn)
+                .path(path.clone())?
+                .build()
+                .await?;
+            if dev.device_type().await? != device_type::WIFI {
+                return Err(ConnectionError::NotAWifiDevice {
+                    interface: name.to_string(),
+                });
+            }
+            Ok(path)
+        }
+    }
+}
+
 /// Finds an access point by SSID.
 ///
 /// Searches through all visible access points on the wireless device
@@ -575,6 +616,7 @@ pub(crate) async fn connect_to_bssid(
     ssid: &str,
     bssid: Option<&str>,
     creds: WifiSecurity,
+    interface: Option<&str>,
     timeout_config: Option<TimeoutConfig>,
 ) -> Result<()> {
     if let Some(b) = bssid {
@@ -582,15 +624,16 @@ pub(crate) async fn connect_to_bssid(
     }
 
     match bssid {
-        None => connect(conn, ssid, creds, timeout_config).await,
+        None => connect(conn, ssid, creds, interface, timeout_config).await,
         Some(target_bssid) => {
             validate_ssid(ssid)?;
             validate_wifi_security(&creds)?;
 
             debug!(
-                "Connecting to '{}' BSSID={} | secured={} is_psk={} is_eap={}",
+                "Connecting to '{}' BSSID={} on {:?} | secured={} is_psk={} is_eap={}",
                 ssid,
                 target_bssid,
+                interface,
                 creds.secured(),
                 creds.is_psk(),
                 creds.is_eap()
@@ -599,7 +642,7 @@ pub(crate) async fn connect_to_bssid(
             let nm = NMProxy::new(conn).await?;
             let saved_raw = get_saved_connection_path(conn, ssid).await?;
             let decision = decide_saved_connection(saved_raw, &creds)?;
-            let wifi_device = find_wifi_device(conn, &nm).await?;
+            let wifi_device = resolve_wifi_device(conn, &nm, interface).await?;
             let wifi = NMWirelessProxy::builder(conn)
                 .path(wifi_device.clone())?
                 .build()
@@ -914,11 +957,12 @@ pub(crate) async fn is_connected(conn: &Connection, ssid: &str) -> Result<bool> 
 /// Returns `Ok(())` if disconnected successfully or if no active connection exists.
 pub(crate) async fn disconnect(
     conn: &Connection,
+    interface: Option<&str>,
     timeout_config: Option<TimeoutConfig>,
 ) -> Result<()> {
     let nm = NMProxy::new(conn).await?;
 
-    let wifi_device = match find_wifi_device(conn, &nm).await {
+    let wifi_device = match resolve_wifi_device(conn, &nm, interface).await {
         Ok(dev) => dev,
         Err(ConnectionError::NoWifiDevice) => {
             debug!("No WiFi device found");
@@ -940,6 +984,24 @@ pub(crate) async fn disconnect(
 
     if let Ok(conns) = nm.active_connections().await {
         for conn_path in conns {
+            let active = match crate::dbus::NMActiveConnectionProxy::builder(conn)
+                .path(conn_path.clone())?
+                .build()
+                .await
+            {
+                Ok(p) => p,
+                Err(e) => {
+                    warn!("Failed to build active connection proxy: {}", e);
+                    continue;
+                }
+            };
+            let owns_device = match active.devices().await {
+                Ok(devs) => devs.iter().any(|d| d == &wifi_device),
+                Err(_) => false,
+            };
+            if !owns_device {
+                continue;
+            }
             match nm.deactivate_connection(conn_path.clone()).await {
                 Ok(_) => debug!("Connection deactivated"),
                 Err(e) => warn!("Failed to deactivate connection: {}", e),

--- a/nmrs/src/core/mod.rs
+++ b/nmrs/src/core/mod.rs
@@ -13,3 +13,4 @@ pub(crate) mod rfkill;
 pub(crate) mod scan;
 pub(crate) mod state_wait;
 pub(crate) mod vpn;
+pub(crate) mod wifi_device;

--- a/nmrs/src/core/scan.rs
+++ b/nmrs/src/core/scan.rs
@@ -17,14 +17,16 @@ use crate::util::utils::{
     decode_ssid_or_empty, decode_ssid_or_hidden, get_ip_addresses_from_active_connection,
 };
 
-/// Triggers a Wi-Fi scan on all wireless devices.
+/// Triggers a Wi-Fi scan.
 ///
-/// Requests NetworkManager to scan for available networks. The scan
-/// runs asynchronously; call `list_networks` after a delay to see results.
-pub(crate) async fn scan_networks(conn: &Connection) -> Result<()> {
+/// When `interface` is `None`, scans on every Wi-Fi device.
+/// When `Some`, scans only the matching device.
+/// The scan runs asynchronously; call [`list_networks`] after a delay.
+pub(crate) async fn scan_networks(conn: &Connection, interface: Option<&str>) -> Result<()> {
     let nm = NMProxy::new(conn).await?;
     let devices = nm.get_devices().await?;
 
+    let mut scanned_any = false;
     for dp in devices {
         let d_proxy = NMDeviceProxy::builder(conn)
             .path(dp.clone())?
@@ -46,6 +48,13 @@ pub(crate) async fn scan_networks(conn: &Connection) -> Result<()> {
             continue;
         }
 
+        if let Some(want) = interface {
+            let iface = d_proxy.interface().await.unwrap_or_default();
+            if iface != want {
+                continue;
+            }
+        }
+
         let wifi = NMWirelessProxy::builder(conn)
             .path(dp.clone())?
             .build()
@@ -58,6 +67,15 @@ pub(crate) async fn scan_networks(conn: &Connection) -> Result<()> {
                 context: format!("failed to request Wi-Fi scan on device {}", dp.as_str()),
                 source: e,
             })?;
+        scanned_any = true;
+    }
+
+    if let Some(want) = interface
+        && !scanned_any
+    {
+        return Err(ConnectionError::WifiInterfaceNotFound {
+            interface: want.to_string(),
+        });
     }
 
     Ok(())
@@ -163,8 +181,11 @@ pub(crate) async fn list_access_points(
 ///
 /// Each returned [`Network`] carries the `best_bssid`, `bssids` list, and
 /// `security_features` from the underlying access points.
-pub(crate) async fn list_networks(conn: &Connection) -> Result<Vec<Network>> {
-    let aps = list_access_points(conn, None).await?;
+pub(crate) async fn list_networks(
+    conn: &Connection,
+    interface: Option<&str>,
+) -> Result<Vec<Network>> {
+    let aps = list_access_points(conn, interface).await?;
 
     let mut groups: HashMap<(String, String), Network> = HashMap::new();
 

--- a/nmrs/src/core/wifi_device.rs
+++ b/nmrs/src/core/wifi_device.rs
@@ -1,0 +1,131 @@
+//! Per-Wi-Fi-device enumeration and control.
+//!
+//! NetworkManager's global `WirelessEnabled` flag toggles every Wi-Fi radio
+//! at once. To disable one specific Wi-Fi device while leaving the others
+//! online, we set `Device.Autoconnect = false` and then call
+//! `Device.Disconnect()` — the kernel hands the radio back to NM but no
+//! connection will be re-activated until autoconnect is re-enabled.
+
+use log::{debug, warn};
+use zbus::Connection;
+
+use crate::Result;
+use crate::api::models::{ConnectionError, WifiDevice};
+use crate::core::connection::{disconnect_wifi_and_wait, get_device_by_interface};
+use crate::dbus::{NMAccessPointProxy, NMDeviceProxy, NMProxy, NMWirelessProxy};
+use crate::types::constants::device_type;
+use crate::util::utils::decode_ssid_or_hidden;
+
+/// Lists every managed Wi-Fi device with current MAC, state, and active SSID.
+pub(crate) async fn list_wifi_devices(conn: &Connection) -> Result<Vec<WifiDevice>> {
+    let nm = NMProxy::new(conn).await?;
+    let paths = nm.get_devices().await?;
+
+    let mut out = Vec::new();
+    for p in paths {
+        let dev = NMDeviceProxy::builder(conn)
+            .path(p.clone())?
+            .build()
+            .await?;
+        if dev.device_type().await? != device_type::WIFI {
+            continue;
+        }
+
+        let interface = dev.interface().await.unwrap_or_default();
+        let hw_address = dev
+            .hw_address()
+            .await
+            .unwrap_or_else(|_| String::from("00:00:00:00:00:00"));
+        let permanent_hw_address = dev.perm_hw_address().await.ok();
+        let driver = dev.driver().await.ok();
+        let state = dev.state().await?.into();
+        let managed = dev.managed().await.unwrap_or(false);
+        let autoconnect = dev.autoconnect().await.unwrap_or(true);
+
+        let wifi = NMWirelessProxy::builder(conn)
+            .path(p.clone())?
+            .build()
+            .await?;
+        let active_ap_path = wifi.active_access_point().await.ok();
+        let (is_active, active_ssid) = match active_ap_path {
+            Some(ap_path) if ap_path.as_str() != "/" => {
+                match NMAccessPointProxy::builder(conn)
+                    .path(ap_path)?
+                    .build()
+                    .await
+                {
+                    Ok(ap) => match ap.ssid().await {
+                        Ok(bytes) => (true, Some(decode_ssid_or_hidden(&bytes).into_owned())),
+                        Err(_) => (true, None),
+                    },
+                    Err(_) => (true, None),
+                }
+            }
+            _ => (false, None),
+        };
+
+        out.push(WifiDevice {
+            path: p,
+            interface,
+            hw_address,
+            permanent_hw_address,
+            driver,
+            state,
+            managed,
+            autoconnect,
+            is_active,
+            active_ssid,
+        });
+    }
+
+    Ok(out)
+}
+
+/// Disable or re-enable a single Wi-Fi device.
+///
+/// `enabled = false` clears `Device.Autoconnect` and disconnects the device.
+/// `enabled = true` re-enables autoconnect; NM will activate any saved
+/// connection on its own.
+///
+/// This is independent of NetworkManager's global `WirelessEnabled` killswitch
+/// (controlled via [`crate::NetworkManager::set_wireless_enabled`]).
+pub(crate) async fn set_wifi_enabled_for_interface(
+    conn: &Connection,
+    interface: &str,
+    enabled: bool,
+) -> Result<()> {
+    let path = match get_device_by_interface(conn, interface).await {
+        Ok(p) => p,
+        Err(ConnectionError::NotFound) => {
+            return Err(ConnectionError::WifiInterfaceNotFound {
+                interface: interface.to_string(),
+            });
+        }
+        Err(e) => return Err(e),
+    };
+
+    let dev = NMDeviceProxy::builder(conn)
+        .path(path.clone())?
+        .build()
+        .await?;
+    if dev.device_type().await? != device_type::WIFI {
+        return Err(ConnectionError::NotAWifiDevice {
+            interface: interface.to_string(),
+        });
+    }
+
+    debug!("setting Autoconnect={} for {}", enabled, interface);
+    if let Err(e) = dev.set_autoconnect(enabled).await {
+        warn!("failed to set autoconnect on {}: {}", interface, e);
+        return Err(ConnectionError::DbusOperation {
+            context: format!("failed to set Autoconnect on {}", interface),
+            source: e,
+        });
+    }
+
+    if !enabled {
+        disconnect_wifi_and_wait(conn, &path, None).await?;
+    }
+
+    Ok(())
+}

--- a/nmrs/src/dbus/device.rs
+++ b/nmrs/src/dbus/device.rs
@@ -64,6 +64,17 @@ pub trait NMDevice {
     #[zbus(property)]
     fn active_connection(&self) -> Result<OwnedObjectPath>;
 
+    /// Whether NM automatically activates known connections on this device.
+    #[zbus(property)]
+    fn autoconnect(&self) -> Result<bool>;
+
+    /// Set the per-device autoconnect flag.
+    #[zbus(property)]
+    fn set_autoconnect(&self, value: bool) -> Result<()>;
+
+    /// Disconnect the active connection on this device, if any.
+    fn disconnect(&self) -> Result<()>;
+
     /// Signal emitted when device state changes.
     ///
     /// The method is named `device_state_changed` to avoid conflicts with the

--- a/nmrs/src/lib.rs
+++ b/nmrs/src/lib.rs
@@ -13,14 +13,14 @@
 //! # async fn example() -> nmrs::Result<()> {
 //! let nm = NetworkManager::new().await?;
 //!
-//! // List visible networks
-//! let networks = nm.list_networks().await?;
+//! // List visible networks (None = all Wi-Fi devices)
+//! let networks = nm.list_networks(None).await?;
 //! for net in &networks {
 //!     println!("{} - Signal: {}%", net.ssid, net.strength.unwrap_or(0));
 //! }
 //!
-//! // Connect to a network
-//! nm.connect("MyNetwork", WifiSecurity::WpaPsk {
+//! // Connect to a network on the first Wi-Fi device
+//! nm.connect("MyNetwork", None, WifiSecurity::WpaPsk {
 //!     psk: "password123".into()
 //! }).await?;
 //!
@@ -135,10 +135,10 @@
 //! let nm = NetworkManager::new().await?;
 //!
 //! // Open network
-//! nm.connect("OpenWiFi", WifiSecurity::Open).await?;
+//! nm.connect("OpenWiFi", None, WifiSecurity::Open).await?;
 //!
 //! // WPA-PSK (password-protected)
-//! nm.connect("HomeWiFi", WifiSecurity::WpaPsk {
+//! nm.connect("HomeWiFi", None, WifiSecurity::WpaPsk {
 //!     psk: "my_password".into()
 //! }).await?;
 //!
@@ -149,7 +149,7 @@
 //!     .with_method(EapMethod::Peap)
 //!     .with_phase2(Phase2::Mschapv2);
 //!
-//! nm.connect("CorpWiFi", WifiSecurity::WpaEap {
+//! nm.connect("CorpWiFi", None, WifiSecurity::WpaEap {
 //!     opts: eap_opts
 //! }).await?;
 //!
@@ -170,7 +170,7 @@
 //! # async fn example() -> nmrs::Result<()> {
 //! let nm = NetworkManager::new().await?;
 //!
-//! match nm.connect("MyNetwork", WifiSecurity::WpaPsk {
+//! match nm.connect("MyNetwork", None, WifiSecurity::WpaPsk {
 //!     psk: "wrong_password".into()
 //! }).await {
 //!     Ok(_) => println!("Connected successfully"),
@@ -352,10 +352,12 @@ pub use api::models::{
     ConnectionStateReason, Device, DeviceState, DeviceType, EapMethod, EapOptions, Network,
     NetworkInfo, OpenVpnAuthType, OpenVpnCompression, OpenVpnConfig, OpenVpnProxy, Phase2,
     RadioState, SecurityFeatures, StateReason, TimeoutConfig, VpnConfig, VpnConfiguration,
-    VpnConnection, VpnConnectionInfo, VpnCredentials, VpnDetails, VpnRoute, VpnType, WifiSecurity,
-    WireGuardConfig, WireGuardPeer, connection_state_reason_to_error, reason_to_error,
+    VpnConnection, VpnConnectionInfo, VpnCredentials, VpnDetails, VpnRoute, VpnType, WifiDevice,
+    WifiSecurity, WireGuardConfig, WireGuardPeer, connection_state_reason_to_error,
+    reason_to_error,
 };
 pub use api::network_manager::NetworkManager;
+pub use api::wifi_scope::WifiScope;
 
 /// A specialized `Result` type for network operations.
 ///

--- a/nmrs/tests/integration_test.rs
+++ b/nmrs/tests/integration_test.rs
@@ -212,7 +212,7 @@ async fn test_scan_networks() {
     let _ = nm.wait_for_wifi_ready().await;
 
     // Request a scan
-    let result = nm.scan_networks().await;
+    let result = nm.scan_networks(None).await;
 
     // Scan should either succeed or fail gracefully
     match result {
@@ -245,11 +245,14 @@ async fn test_list_networks() {
     let _ = nm.wait_for_wifi_ready().await;
 
     // Request a scan first
-    let _ = nm.scan_networks().await;
+    let _ = nm.scan_networks(None).await;
     sleep(Duration::from_secs(2)).await;
 
     // List networks
-    let networks = nm.list_networks().await.expect("Failed to list networks");
+    let networks = nm
+        .list_networks(None)
+        .await
+        .expect("Failed to list networks");
 
     // Verify network structure
     for network in &networks {
@@ -337,11 +340,14 @@ async fn test_show_details() {
     let _ = nm.wait_for_wifi_ready().await;
 
     // Request a scan first
-    let _ = nm.scan_networks().await;
+    let _ = nm.scan_networks(None).await;
     sleep(Duration::from_secs(2)).await;
 
     // List networks
-    let networks = nm.list_networks().await.expect("Failed to list networks");
+    let networks = nm
+        .list_networks(None)
+        .await
+        .expect("Failed to list networks");
 
     // Try to show details for the first network (if any)
     if let Some(network) = networks.first() {
@@ -440,11 +446,14 @@ async fn test_connect_open_network() {
     let _ = nm.wait_for_wifi_ready().await;
 
     // Request a scan first
-    let _ = nm.scan_networks().await;
+    let _ = nm.scan_networks(None).await;
     sleep(Duration::from_secs(2)).await;
 
     // List networks to find an open network
-    let networks = nm.list_networks().await.expect("Failed to list networks");
+    let networks = nm
+        .list_networks(None)
+        .await
+        .expect("Failed to list networks");
 
     // Find an open network (if any)
     let open_network = networks.iter().find(|n| !n.secured);
@@ -459,7 +468,7 @@ async fn test_connect_open_network() {
         }
 
         // Try to connect to the open network
-        let result = nm.connect(test_ssid, WifiSecurity::Open).await;
+        let result = nm.connect(test_ssid, None, WifiSecurity::Open).await;
 
         match result {
             Ok(_) => {
@@ -500,11 +509,14 @@ async fn test_connect_psk_network_with_empty_password() {
     let _ = nm.wait_for_wifi_ready().await;
 
     // Request a scan first
-    let _ = nm.scan_networks().await;
+    let _ = nm.scan_networks(None).await;
     sleep(Duration::from_secs(2)).await;
 
     // List networks to find a PSK network
-    let networks = nm.list_networks().await.expect("Failed to list networks");
+    let networks = nm
+        .list_networks(None)
+        .await
+        .expect("Failed to list networks");
 
     // Find a PSK network (if any)
     let psk_network = networks.iter().find(|n| n.is_psk);
@@ -527,7 +539,7 @@ async fn test_connect_psk_network_with_empty_password() {
         if has_saved {
             // Try to connect with empty password (should use saved credentials)
             let result = nm
-                .connect(test_ssid, WifiSecurity::WpaPsk { psk: String::new() })
+                .connect(test_ssid, None, WifiSecurity::WpaPsk { psk: String::new() })
                 .await;
 
             match result {
@@ -652,11 +664,14 @@ async fn test_network_properties() {
     let _ = nm.wait_for_wifi_ready().await;
 
     // Request a scan first
-    let _ = nm.scan_networks().await;
+    let _ = nm.scan_networks(None).await;
     sleep(Duration::from_secs(2)).await;
 
     // List networks
-    let networks = nm.list_networks().await.expect("Failed to list networks");
+    let networks = nm
+        .list_networks(None)
+        .await
+        .expect("Failed to list networks");
 
     // Verify network properties
     for network in &networks {
@@ -707,7 +722,7 @@ async fn test_multiple_scan_requests() {
     for i in 0..3 {
         nm.wait_for_wifi_ready().await.expect("WiFi not ready");
 
-        let result = nm.scan_networks().await;
+        let result = nm.scan_networks(None).await;
         match result {
             Ok(_) => eprintln!("Scan {} succeeded", i + 1),
             Err(e) => eprintln!("Scan {} failed: {}", i + 1, e),
@@ -720,7 +735,10 @@ async fn test_multiple_scan_requests() {
     }
 
     // List networks after multiple scans
-    let networks = nm.list_networks().await.expect("Failed to list networks");
+    let networks = nm
+        .list_networks(None)
+        .await
+        .expect("Failed to list networks");
     eprintln!("Found {} networks after multiple scans", networks.len());
 }
 
@@ -741,7 +759,7 @@ async fn test_concurrent_operations() {
 
     // Run multiple operations concurrently
     let (devices_result, wifi_state_result, networks_result) =
-        tokio::join!(nm.list_devices(), nm.wifi_state(), nm.list_networks());
+        tokio::join!(nm.list_devices(), nm.wifi_state(), nm.list_networks(None));
 
     // All should succeed
     assert!(devices_result.is_ok(), "list_devices should succeed");


### PR DESCRIPTION
This PR adds per-interface Wi-Fi scoping for multi-radio systems and bumps to 3.0.

**Added**
- `WifiDevice`, `list_wifi_devices()`, `wifi_device_by_interface()`
- `WifiScope` via `nm.wifi("wlan1")` — `scan / list_networks / list_access_points / connect / connect_to_bssid / disconnect / set_enabled / forget` all pinned to one radio
- `set_wifi_enabled(interface, bool)` for per-radio enable/disable (uses `Device.Autoconnect` + `Device.Disconnect()`, independent of the global wireless killswitch)
- `WifiInterfaceNotFound`, `NotAWifiDevice` errors
- `examples/multi_wifi.rs`

**Breaking changes**
- `connect`, `connect_to_bssid`, `disconnect`, `scan_networks`, `list_networks` take an `interface: Option<&str>` argument (`None` = previous behavior)
- `set_wifi_enabled` now requires `(interface, bool)`
- Removed deprecated `wifi_enabled()`, `wifi_hardware_enabled()`, no-arg `set_wifi_enabled(bool)` — use `wifi_state()` / `set_wireless_enabled()`
- `disconnect` now correctly only deactivates active connections owned by the targeted device (was deactivating every active connection)

**Migration**
| Old | New |
|---|---|
| `nm.connect(ssid, creds)` | `nm.connect(ssid, None, creds)` |
| `nm.connect_to_bssid(ssid, bssid, creds)` | `nm.connect_to_bssid(ssid, bssid, None, creds)` |
| `nm.disconnect()` | `nm.disconnect(None)` |
| `nm.scan_networks()` / `nm.list_networks()` | add `(None)` |
| `nm.set_wifi_enabled(true)` | `nm.set_wireless_enabled(true)` |
| `nm.wifi_enabled()` / `wifi_hardware_enabled()` | `nm.wifi_state()` |
