### PR TITLE
feat: implement loopback

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ To follow and/or discuss the development of nmrs, you can join the [public Disco
 - [x] Generic  
 - [x] Wireless  
 - [ ] Any  
-- [X] Wired  
+- [x] Wired  
 - [ ] ADSL  
-- [X] Bluetooth  
+- [x] Bluetooth  
 - [ ] Bond  
 - [ ] Bridge  
 - [ ] Dummy  
@@ -122,7 +122,7 @@ To follow and/or discuss the development of nmrs, you can join the [public Disco
 - [ ] IP Tunnel  
 - [ ] IPVLAN *(NetworkManager ≥ 1.52)*  
 - [ ] Lowpan  
-- [ ] Loopback  
+- [x] Loopback  
 - [ ] MACsec  
 - [ ] MACVLAN  
 - [ ] Modem  

--- a/nmrs/CHANGELOG.md
+++ b/nmrs/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the `nmrs` crate will be documented in this file.
 
 ## [Unreleased]
+- Implement loopback support ([#391](https://github.com/cachebag/nmrs/issues/391))
 
 ## [3.0.1] - 2026-04-25
 ### Changed

--- a/nmrs/src/api/models/device.rs
+++ b/nmrs/src/api/models/device.rs
@@ -27,6 +27,8 @@ use zvariant::OwnedObjectPath;
 ///         println!("  This is an Ethernet device");
 ///     } else if device.is_bluetooth() {
 ///         println!("  This is a Bluetooth device");
+///     } else if device.is_loopback() {
+///         println!("  This is a loopback device");
 ///     }
 ///
 ///     if let Some(driver) = &device.driver {
@@ -299,6 +301,12 @@ impl Device {
     #[must_use]
     pub fn is_bluetooth(&self) -> bool {
         matches!(self.device_type, DeviceType::Bluetooth)
+    }
+
+    /// Returns `true` if this is a loopback device (e.g., `lo`).
+    #[must_use]
+    pub fn is_loopback(&self) -> bool {
+        matches!(self.device_type, DeviceType::Loopback)
     }
 }
 

--- a/nmrs/src/types/device_type_registry.rs
+++ b/nmrs/src/types/device_type_registry.rs
@@ -320,6 +320,17 @@ mod tests {
     }
 
     #[test]
+    fn loopback_type_info() {
+        let info = get_device_type_info(32).expect("Loopback should be registered");
+        assert_eq!(info.nm_type_code(), 32);
+        assert_eq!(info.display_name(), "Loopback");
+        assert_eq!(info.connection_type(), "loopback");
+        assert!(!info.supports_scanning());
+        assert!(!info.requires_specific_object());
+        assert!(!info.has_global_enabled_state());
+    }
+
+    #[test]
     fn unknown_device_type() {
         let info = get_device_type_info(999);
         assert!(info.is_none());


### PR DESCRIPTION
Implements loopback. Added `Device::is_loopback()` as a convenience method matching `is_wired()`, `is_wireless()`, `is_bluetooth()`. 

