### PR TITLE
fix(#420): remove `service-type` insertion from `wireguard` builder

### DIFF
--- a/nmrs/CHANGELOG.md
+++ b/nmrs/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to the `nmrs` crate will be documented in this file.
 
 ## [Unreleased]
+### Fixed
+- WireGuard builder now sets `service-type` property correctly ([#421](https://github.com/networkmanager-rs/nmrs/pull/421))
 
 ## [3.1.3] - 2026-05-14
 ### Fixed
@@ -11,7 +13,7 @@ All notable changes to the `nmrs` crate will be documented in this file.
 (No changes documented)
 
 ## [3.1.2] - 2026-05-14
-- `set_bluetooth_radio_enabled` now toggles kernel rfkill before BlueZ adapter `Powered`, fixing airplane-mode state desync with rfkill-based consumers ([#417](https://github.com/cachebag/nmrs/issues/418))
+- `set_bluetooth_radio_enabled` now toggles kernel rfkill before BlueZ adapter `Powered`, fixing airplane-mode state desync with rfkill-based consumers ([#417](https://github.com/networkmanager-rs/nmrs/issues/418))
 
 ## [3.1.1] - 2026-05-13
 ### Fixed
@@ -21,17 +23,17 @@ All notable changes to the `nmrs` crate will be documented in this file.
   those radios were disabled, preventing UI/state divergence where airplane
   mode appears to fail while radios remain disabled. On hosts with no
   Wi-Fi/WWAN device detected, `set_airplane_mode` can still return
-  `BluetoothToggleFailed`. ([#417](https://github.com/cachebag/nmrs/issues/417))
+  `BluetoothToggleFailed`. ([#417](https://github.com/networkmanager-rs/nmrs/issues/417))
 
 ## [3.1.0] - 2026-05-08
-- Implement loopback support ([#391](https://github.com/cachebag/nmrs/issues/391))
-- Implement add VLAN (802.1Q) device support with VlanConfig model and connection builder([#392](https://github.com/cachebag/nmrs/issues/392))
+- Implement loopback support ([#391](https://github.com/networkmanager-rs/nmrs/issues/391))
+- Implement add VLAN (802.1Q) device support with VlanConfig model and connection builder([#392](https://github.com/networkmanager-rs/nmrs/issues/392))
 
 ### Added
 - `RadioState::present` indicates whether a controllable instance of the radio
   exists on the host. `RadioState::with_presence(enabled, hardware_enabled,
   present)` constructor; `RadioState::new` keeps existing behavior and defaults
-  `present = true`. ([#396](https://github.com/cachebag/nmrs/issues/396))
+  `present = true`. ([#396](https://github.com/networkmanager-rs/nmrs/issues/396))
 
 ### Fixed
 - `NetworkManager::wifi_state` and `wwan_state` now set `RadioState::present`

--- a/nmrs/src/api/builders/vpn.rs
+++ b/nmrs/src/api/builders/vpn.rs
@@ -440,17 +440,16 @@ mod tests {
     }
 
     #[test]
-    fn vpn_section_has_wireguard_service_type() {
+    fn wireguard_section_has_no_service_type() {
         let creds = create_test_credentials();
         let opts = create_test_options();
 
         let settings = build_wireguard_connection(&creds, &opts).unwrap();
-        let vpn = settings.get("wireguard").unwrap();
+        let wg = settings.get("wireguard").unwrap();
 
-        let service_type = vpn.get("service-type").unwrap();
-        assert_eq!(
-            service_type,
-            &Value::from("org.freedesktop.NetworkManager.wireguard")
+        assert!(
+            wg.get("service-type").is_none(),
+            "kernel WireGuard connections must not have a service-type property"
         );
     }
 

--- a/nmrs/src/api/builders/wireguard_builder.rs
+++ b/nmrs/src/api/builders/wireguard_builder.rs
@@ -245,10 +245,6 @@ impl WireGuardBuilder {
 
         // Build wireguard section
         let mut wireguard = HashMap::new();
-        wireguard.insert(
-            "service-type",
-            Value::from("org.freedesktop.NetworkManager.wireguard"),
-        );
         wireguard.insert("private-key", Value::from(private_key));
 
         // Build peers array


### PR DESCRIPTION
`WireGuardBuilder::build()` inserted a service-type property into the `wireguard` settings section. WireGuard in NetworkManager is a native kernel connection type (connection.type = "wireguard"), not a plugin VPN. The wireguard section does not have a service-type property — only the vpn section for plugin VPNs (like OpenVPN) does. This caused NM to reject the profile with wireguard.service-type: unknown property.

Fixes #420 