### PR TITLE
fix(#352): guard connect operations with async mutex to prevent TOCTOU race

### DIFF
--- a/nmrs/CHANGELOG.md
+++ b/nmrs/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the `nmrs` crate will be documented in this file.
 
 ## [Unreleased]
+### Fixed
+- Guard connect operations with async mutex to prevent TOCTOU race between `is_connecting()` and `connect()` ([#427](https://github.com/networkmanager-rs/nmrs/pull/427))
+- Switches saved connection lookup to use `validate_connection_name()` instead of `validate_ssid()`. Using the latter causes VPN profile names longer than 32-bytes to pass through.([#426](https://github.com/networkmanager-rs/nmrs/pull/426))
 
 ## [3.1.5] - 2026-05-20
 ### Fixed

--- a/nmrs/CHANGELOG.md
+++ b/nmrs/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the `nmrs` crate will be documented in this file.
 ## [Unreleased]
 ### Fixed
 - Guard connect operations with async mutex to prevent TOCTOU race between `is_connecting()` and `connect()` ([#427](https://github.com/networkmanager-rs/nmrs/pull/427))
-- Switches saved connection lookup to use `validate_connection_name()` instead of `validate_ssid()`. Using the latter causes VPN profile names longer than 32-bytes to pass through.([#426](https://github.com/networkmanager-rs/nmrs/pull/426))
+- Switches saved connection lookup to use `validate_connection_name()` instead of `validate_ssid()`. Using the latter causes VPN profile names longer than 32-bytes to pass through. ([#426](https://github.com/networkmanager-rs/nmrs/pull/426))
 
 ## [3.1.5] - 2026-05-20
 ### Fixed

--- a/nmrs/src/api/models/error.rs
+++ b/nmrs/src/api/models/error.rs
@@ -254,6 +254,13 @@ pub enum ConnectionError {
     #[error("bluetooth toggle failed: {0}")]
     BluetoothToggleFailed(String),
 
+    /// A connection operation is already in progress.
+    ///
+    /// Returned by [`try_connect`](crate::NetworkManager::try_connect) and
+    /// related `try_*` methods when another task is already connecting.
+    #[error("a connection operation is already in progress")]
+    ConnectionInProgress,
+
     /// Invalid VLAN ID (must be 1-4094).
     #[error("invalid VLAN ID {id}: must be between 1 and 4094")]
     InvalidVlanId {

--- a/nmrs/src/api/network_manager.rs
+++ b/nmrs/src/api/network_manager.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
-use tokio::sync::watch;
+use tokio::sync::{Mutex, watch};
 use zbus::Connection;
 use zvariant::OwnedValue;
 
@@ -134,15 +135,26 @@ use crate::types::constants::device_type;
 ///
 /// # Concurrency
 ///
-/// Concurrent connection operations (e.g. calling [`connect`](Self::connect)
-/// from multiple tasks simultaneously) are **not supported** and may cause
-/// race conditions. Use [`is_connecting`](Self::is_connecting) to check
-/// whether a connection operation is already in progress before starting
-/// a new one.
+/// All connection-mutating operations (`connect`, `connect_to_bssid`,
+/// `connect_wired`, `connect_bluetooth`, `connect_vpn*`, `disconnect`)
+/// are serialized by an internal mutex. If one task is already inside a
+/// connect call, a second call will wait for the first to finish before
+/// proceeding.
+///
+/// For callers that want to fail fast instead of waiting, use the
+/// `try_connect` / `try_connect_to_bssid` family: these acquire the
+/// mutex, check [`is_connecting`](Self::is_connecting) under the lock,
+/// and return [`ConnectionInProgress`](crate::ConnectionError::ConnectionInProgress)
+/// immediately if another operation is in flight.
+///
+/// The mutex is shared across all clones of a `NetworkManager` instance.
+/// Operations through a [`WifiScope`](crate::WifiScope) obtained from
+/// [`wifi()`](Self::wifi) share the same mutex as the parent.
 #[derive(Debug, Clone)]
 pub struct NetworkManager {
     conn: Connection,
     timeout_config: crate::api::models::TimeoutConfig,
+    connect_guard: Arc<Mutex<()>>,
 }
 
 impl NetworkManager {
@@ -155,6 +167,7 @@ impl NetworkManager {
         Ok(Self {
             conn,
             timeout_config: crate::api::models::TimeoutConfig::default(),
+            connect_guard: Arc::new(Mutex::new(())),
         })
     }
 
@@ -184,6 +197,7 @@ impl NetworkManager {
         Ok(Self {
             conn,
             timeout_config,
+            connect_guard: Arc::new(Mutex::new(())),
         })
     }
 
@@ -293,6 +307,7 @@ impl NetworkManager {
             conn: self.conn.clone(),
             interface: interface.into(),
             timeout_config: self.timeout_config,
+            connect_guard: self.connect_guard.clone(),
         }
     }
 
@@ -371,6 +386,7 @@ impl NetworkManager {
         interface: Option<&str>,
         creds: WifiSecurity,
     ) -> Result<()> {
+        let _guard = self.connect_guard.lock().await;
         connect_to_bssid(
             &self.conn,
             ssid,
@@ -400,6 +416,7 @@ impl NetworkManager {
         interface: Option<&str>,
         creds: WifiSecurity,
     ) -> Result<()> {
+        let _guard = self.connect_guard.lock().await;
         connect(
             &self.conn,
             ssid,
@@ -420,6 +437,7 @@ impl NetworkManager {
     ///
     /// Returns `ConnectionError::NoWiredDevice` if no wired device is found.
     pub async fn connect_wired(&self) -> Result<()> {
+        let _guard = self.connect_guard.lock().await;
         connect_wired(&self.conn, Some(self.timeout_config)).await
     }
 
@@ -444,6 +462,7 @@ impl NetworkManager {
     ///
     /// ```
     pub async fn connect_bluetooth(&self, name: &str, identity: &BluetoothIdentity) -> Result<()> {
+        let _guard = self.connect_guard.lock().await;
         connect_bluetooth(&self.conn, name, identity, Some(self.timeout_config)).await
     }
 
@@ -514,6 +533,7 @@ impl NetworkManager {
     where
         C: VpnConfig + Into<VpnConfiguration>,
     {
+        let _guard = self.connect_guard.lock().await;
         connect_vpn(&self.conn, config.into(), Some(self.timeout_config)).await
     }
 
@@ -563,7 +583,8 @@ impl NetworkManager {
             builder = builder.password(p);
         }
         let config = builder.build()?;
-        self.connect_vpn(config).await
+        let _guard = self.connect_guard.lock().await;
+        connect_vpn(&self.conn, config.into(), Some(self.timeout_config)).await
     }
 
     /// Disconnects from an active VPN connection by name.
@@ -631,6 +652,7 @@ impl NetworkManager {
     /// # }
     /// ```
     pub async fn connect_vpn_by_uuid(&self, uuid: &str) -> Result<()> {
+        let _guard = self.connect_guard.lock().await;
         connect_vpn_by_uuid(&self.conn, uuid, Some(self.timeout_config)).await
     }
 
@@ -639,6 +661,7 @@ impl NetworkManager {
     /// Fails with [`VpnIdAmbiguous`](crate::ConnectionError::VpnIdAmbiguous)
     /// if multiple VPNs share the same name.
     pub async fn connect_vpn_by_id(&self, id: &str) -> Result<()> {
+        let _guard = self.connect_guard.lock().await;
         connect_vpn_by_id(&self.conn, id, Some(self.timeout_config)).await
     }
 
@@ -900,8 +923,12 @@ impl NetworkManager {
     /// A device is considered "connecting" when its state is one of:
     /// Prepare, Config, NeedAuth, IpConfig, IpCheck, Secondaries, or Deactivating.
     ///
-    /// Use this to guard against concurrent connection attempts, which are
-    /// not supported and may cause undefined behavior.
+    /// This is a point-in-time snapshot and does **not** hold any lock.
+    /// If you need an atomic "check then connect" operation, use
+    /// [`try_connect`](Self::try_connect) instead, which checks under the
+    /// internal connection mutex and returns
+    /// [`ConnectionInProgress`](crate::ConnectionError::ConnectionInProgress)
+    /// when another operation is in flight.
     ///
     /// # Example
     ///
@@ -919,6 +946,89 @@ impl NetworkManager {
     /// ```
     pub async fn is_connecting(&self) -> Result<bool> {
         is_connecting(&self.conn).await
+    }
+
+    /// Atomically checks that no device is currently connecting, then
+    /// connects to the given Wi-Fi network.
+    ///
+    /// This is the race-free alternative to calling
+    /// [`is_connecting`](Self::is_connecting) followed by
+    /// [`connect`](Self::connect). Both the check and the connection
+    /// happen under the internal connection mutex, so no other task
+    /// sharing this `NetworkManager` instance can start a connection
+    /// in between.
+    ///
+    /// Returns
+    /// [`ConnectionInProgress`](crate::ConnectionError::ConnectionInProgress)
+    /// if any device is already in a transitional state.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use nmrs::{NetworkManager, WifiSecurity, ConnectionError};
+    ///
+    /// # async fn example() -> nmrs::Result<()> {
+    /// let nm = NetworkManager::new().await?;
+    ///
+    /// match nm.try_connect("MyNetwork", None, WifiSecurity::WpaPsk {
+    ///     psk: "password".into(),
+    /// }).await {
+    ///     Ok(()) => println!("Connected!"),
+    ///     Err(ConnectionError::ConnectionInProgress) => {
+    ///         eprintln!("Another connection is already in progress");
+    ///     }
+    ///     Err(e) => eprintln!("Error: {e}"),
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn try_connect(
+        &self,
+        ssid: &str,
+        interface: Option<&str>,
+        creds: WifiSecurity,
+    ) -> Result<()> {
+        let _guard = self.connect_guard.lock().await;
+        if is_connecting(&self.conn).await? {
+            return Err(crate::ConnectionError::ConnectionInProgress);
+        }
+        connect(
+            &self.conn,
+            ssid,
+            creds,
+            interface,
+            Some(self.timeout_config),
+        )
+        .await
+    }
+
+    /// Atomically checks that no device is currently connecting, then
+    /// connects to a specific access point by SSID and optional BSSID.
+    ///
+    /// Like [`try_connect`](Self::try_connect) but targets a specific BSSID.
+    /// Returns
+    /// [`ConnectionInProgress`](crate::ConnectionError::ConnectionInProgress)
+    /// if any device is already in a transitional state.
+    pub async fn try_connect_to_bssid(
+        &self,
+        ssid: &str,
+        bssid: Option<&str>,
+        interface: Option<&str>,
+        creds: WifiSecurity,
+    ) -> Result<()> {
+        let _guard = self.connect_guard.lock().await;
+        if is_connecting(&self.conn).await? {
+            return Err(crate::ConnectionError::ConnectionInProgress);
+        }
+        connect_to_bssid(
+            &self.conn,
+            ssid,
+            bssid,
+            creds,
+            interface,
+            Some(self.timeout_config),
+        )
+        .await
     }
 
     /// Check if a network is connected
@@ -952,6 +1062,7 @@ impl NetworkManager {
     /// # }
     /// ```
     pub async fn disconnect(&self, interface: Option<&str>) -> Result<()> {
+        let _guard = self.connect_guard.lock().await;
         disconnect(&self.conn, interface, Some(self.timeout_config)).await
     }
 

--- a/nmrs/src/api/network_manager.rs
+++ b/nmrs/src/api/network_manager.rs
@@ -142,10 +142,13 @@ use crate::types::constants::device_type;
 /// proceeding.
 ///
 /// For callers that want to fail fast instead of waiting, use the
-/// `try_connect` / `try_connect_to_bssid` family: these acquire the
-/// mutex, check [`is_connecting`](Self::is_connecting) under the lock,
-/// and return [`ConnectionInProgress`](crate::ConnectionError::ConnectionInProgress)
-/// immediately if another operation is in flight.
+/// `try_connect` / `try_connect_to_bssid` family: these use
+/// [`try_lock`](tokio::sync::Mutex::try_lock) on the mutex (returning
+/// [`ConnectionInProgress`](crate::ConnectionError::ConnectionInProgress)
+/// if another task holds it), then check [`is_connecting`](Self::is_connecting)
+/// before proceeding. Plain `connect` / `disconnect` use
+/// [`lock`](tokio::sync::Mutex::lock) and will wait until the mutex is
+/// free, which may take up to the configured connection timeout.
 ///
 /// The mutex is shared across all clones of a `NetworkManager` instance.
 /// Operations through a [`WifiScope`](crate::WifiScope) obtained from
@@ -404,6 +407,11 @@ impl NetworkManager {
     /// `None` for the previous behavior of using the first available Wi-Fi
     /// device, or `Some("wlan1")` to pin the connection to a specific
     /// interface.
+    ///
+    /// Concurrent calls on the same [`NetworkManager`] instance are
+    /// serialized: if another task is already connecting, this call waits
+    /// for it to finish (up to the configured timeout). Use
+    /// [`try_connect`](Self::try_connect) to fail immediately instead.
     ///
     /// # Errors
     ///
@@ -956,14 +964,11 @@ impl NetworkManager {
     ///
     /// This is the race-free alternative to calling
     /// [`is_connecting`](Self::is_connecting) followed by
-    /// [`connect`](Self::connect). Both the check and the connection
-    /// happen under the internal connection mutex, so no other task
-    /// sharing this `NetworkManager` instance can start a connection
-    /// in between.
-    ///
-    /// Returns
+    /// [`connect`](Self::connect). Unlike [`connect`](Self::connect), this
+    /// does not wait on the connection mutex: it returns
     /// [`ConnectionInProgress`](crate::ConnectionError::ConnectionInProgress)
-    /// if any device is already in a transitional state.
+    /// if another task holds the mutex or any device is in a transitional
+    /// state.
     ///
     /// # Example
     ///

--- a/nmrs/src/api/network_manager.rs
+++ b/nmrs/src/api/network_manager.rs
@@ -605,6 +605,7 @@ impl NetworkManager {
     /// # }
     /// ```
     pub async fn disconnect_vpn(&self, name: &str) -> Result<()> {
+        let _guard = self.connect_guard.lock().await;
         disconnect_vpn(&self.conn, name).await
     }
 
@@ -667,6 +668,7 @@ impl NetworkManager {
 
     /// Disconnect a VPN by UUID.
     pub async fn disconnect_vpn_by_uuid(&self, uuid: &str) -> Result<()> {
+        let _guard = self.connect_guard.lock().await;
         disconnect_vpn_by_uuid(&self.conn, uuid).await
     }
 
@@ -693,6 +695,7 @@ impl NetworkManager {
     /// Returns an error only if the operation fails unexpectedly.
     /// Returns `Ok(())` if no matching VPN connection is found.
     pub async fn forget_vpn(&self, name: &str) -> Result<()> {
+        let _guard = self.connect_guard.lock().await;
         crate::core::vpn::forget_vpn(&self.conn, name).await
     }
 
@@ -988,7 +991,10 @@ impl NetworkManager {
         interface: Option<&str>,
         creds: WifiSecurity,
     ) -> Result<()> {
-        let _guard = self.connect_guard.lock().await;
+        let _guard = self
+            .connect_guard
+            .try_lock()
+            .map_err(|_| crate::ConnectionError::ConnectionInProgress)?;
         if is_connecting(&self.conn).await? {
             return Err(crate::ConnectionError::ConnectionInProgress);
         }
@@ -1016,7 +1022,10 @@ impl NetworkManager {
         interface: Option<&str>,
         creds: WifiSecurity,
     ) -> Result<()> {
-        let _guard = self.connect_guard.lock().await;
+        let _guard = self
+            .connect_guard
+            .try_lock()
+            .map_err(|_| crate::ConnectionError::ConnectionInProgress)?;
         if is_connecting(&self.conn).await? {
             return Err(crate::ConnectionError::ConnectionInProgress);
         }
@@ -1225,6 +1234,7 @@ impl NetworkManager {
     /// Returns `Ok(())` if one or more connections were deleted successfully,
     /// or if no matching connections were found.
     pub async fn forget(&self, ssid: &str) -> Result<()> {
+        let _guard = self.connect_guard.lock().await;
         forget_by_name_and_type(
             &self.conn,
             ssid,
@@ -1248,6 +1258,7 @@ impl NetworkManager {
     /// Returns `Ok(())` if the connection was deleted successfully.
     /// Returns `NoSavedConnection` if no matching connection was found.
     pub async fn forget_bluetooth(&self, name: &str) -> Result<()> {
+        let _guard = self.connect_guard.lock().await;
         forget_by_name_and_type(
             &self.conn,
             name,

--- a/nmrs/src/api/wifi_scope.rs
+++ b/nmrs/src/api/wifi_scope.rs
@@ -19,10 +19,15 @@
 //! # }
 //! ```
 
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
 use crate::Result;
 use crate::api::models::access_point::AccessPoint;
 use crate::api::models::{Network, WifiSecurity};
 use crate::core::connection::{connect, connect_to_bssid, disconnect, forget_by_name_and_type};
+use crate::core::device::is_connecting;
 use crate::core::scan::{list_access_points, list_networks, scan_networks};
 use crate::core::wifi_device::set_wifi_enabled_for_interface;
 use crate::types::constants::device_type;
@@ -36,6 +41,7 @@ pub struct WifiScope {
     pub(crate) conn: zbus::Connection,
     pub(crate) interface: String,
     pub(crate) timeout_config: crate::api::models::TimeoutConfig,
+    pub(crate) connect_guard: Arc<Mutex<()>>,
 }
 
 impl WifiScope {
@@ -62,6 +68,7 @@ impl WifiScope {
 
     /// Connect this interface to the given SSID.
     pub async fn connect(&self, ssid: &str, creds: WifiSecurity) -> Result<()> {
+        let _guard = self.connect_guard.lock().await;
         connect(
             &self.conn,
             ssid,
@@ -79,6 +86,55 @@ impl WifiScope {
         bssid: Option<&str>,
         creds: WifiSecurity,
     ) -> Result<()> {
+        let _guard = self.connect_guard.lock().await;
+        connect_to_bssid(
+            &self.conn,
+            ssid,
+            bssid,
+            creds,
+            Some(&self.interface),
+            Some(self.timeout_config),
+        )
+        .await
+    }
+
+    /// Atomically checks that no device is currently connecting, then
+    /// connects this interface to the given SSID.
+    ///
+    /// Returns
+    /// [`ConnectionInProgress`](crate::ConnectionError::ConnectionInProgress)
+    /// if any device is already in a transitional state.
+    pub async fn try_connect(&self, ssid: &str, creds: WifiSecurity) -> Result<()> {
+        let _guard = self.connect_guard.lock().await;
+        if is_connecting(&self.conn).await? {
+            return Err(crate::ConnectionError::ConnectionInProgress);
+        }
+        connect(
+            &self.conn,
+            ssid,
+            creds,
+            Some(&self.interface),
+            Some(self.timeout_config),
+        )
+        .await
+    }
+
+    /// Atomically checks that no device is currently connecting, then
+    /// connects this interface to a specific BSSID.
+    ///
+    /// Returns
+    /// [`ConnectionInProgress`](crate::ConnectionError::ConnectionInProgress)
+    /// if any device is already in a transitional state.
+    pub async fn try_connect_to_bssid(
+        &self,
+        ssid: &str,
+        bssid: Option<&str>,
+        creds: WifiSecurity,
+    ) -> Result<()> {
+        let _guard = self.connect_guard.lock().await;
+        if is_connecting(&self.conn).await? {
+            return Err(crate::ConnectionError::ConnectionInProgress);
+        }
         connect_to_bssid(
             &self.conn,
             ssid,
@@ -92,6 +148,7 @@ impl WifiScope {
 
     /// Disconnect this interface from its active network, if any.
     pub async fn disconnect(&self) -> Result<()> {
+        let _guard = self.connect_guard.lock().await;
         disconnect(&self.conn, Some(&self.interface), Some(self.timeout_config)).await
     }
 

--- a/nmrs/src/api/wifi_scope.rs
+++ b/nmrs/src/api/wifi_scope.rs
@@ -105,7 +105,10 @@ impl WifiScope {
     /// [`ConnectionInProgress`](crate::ConnectionError::ConnectionInProgress)
     /// if any device is already in a transitional state.
     pub async fn try_connect(&self, ssid: &str, creds: WifiSecurity) -> Result<()> {
-        let _guard = self.connect_guard.lock().await;
+        let _guard = self
+            .connect_guard
+            .try_lock()
+            .map_err(|_| crate::ConnectionError::ConnectionInProgress)?;
         if is_connecting(&self.conn).await? {
             return Err(crate::ConnectionError::ConnectionInProgress);
         }
@@ -131,7 +134,10 @@ impl WifiScope {
         bssid: Option<&str>,
         creds: WifiSecurity,
     ) -> Result<()> {
-        let _guard = self.connect_guard.lock().await;
+        let _guard = self
+            .connect_guard
+            .try_lock()
+            .map_err(|_| crate::ConnectionError::ConnectionInProgress)?;
         if is_connecting(&self.conn).await? {
             return Err(crate::ConnectionError::ConnectionInProgress);
         }
@@ -166,6 +172,7 @@ impl WifiScope {
     /// forgets the profile globally — but is exposed here for ergonomic use
     /// alongside the other per-scope operations.
     pub async fn forget(&self, ssid: &str) -> Result<()> {
+        let _guard = self.connect_guard.lock().await;
         forget_by_name_and_type(
             &self.conn,
             ssid,

--- a/nmrs/src/api/wifi_scope.rs
+++ b/nmrs/src/api/wifi_scope.rs
@@ -27,7 +27,7 @@ use crate::Result;
 use crate::api::models::access_point::AccessPoint;
 use crate::api::models::{Network, WifiSecurity};
 use crate::core::connection::{connect, connect_to_bssid, disconnect, forget_by_name_and_type};
-use crate::core::device::is_connecting;
+use crate::core::device::is_connecting_on_interface;
 use crate::core::scan::{list_access_points, list_networks, scan_networks};
 use crate::core::wifi_device::set_wifi_enabled_for_interface;
 use crate::types::constants::device_type;
@@ -98,18 +98,19 @@ impl WifiScope {
         .await
     }
 
-    /// Atomically checks that no device is currently connecting, then
-    /// connects this interface to the given SSID.
+    /// Atomically checks that this interface is not in a transitional state,
+    /// then connects to the given SSID.
     ///
     /// Returns
     /// [`ConnectionInProgress`](crate::ConnectionError::ConnectionInProgress)
-    /// if any device is already in a transitional state.
+    /// if another task holds the connection mutex or this interface's device
+    /// is already connecting.
     pub async fn try_connect(&self, ssid: &str, creds: WifiSecurity) -> Result<()> {
         let _guard = self
             .connect_guard
             .try_lock()
             .map_err(|_| crate::ConnectionError::ConnectionInProgress)?;
-        if is_connecting(&self.conn).await? {
+        if is_connecting_on_interface(&self.conn, &self.interface).await? {
             return Err(crate::ConnectionError::ConnectionInProgress);
         }
         connect(
@@ -122,12 +123,13 @@ impl WifiScope {
         .await
     }
 
-    /// Atomically checks that no device is currently connecting, then
-    /// connects this interface to a specific BSSID.
+    /// Atomically checks that this interface is not in a transitional state,
+    /// then connects to a specific BSSID.
     ///
     /// Returns
     /// [`ConnectionInProgress`](crate::ConnectionError::ConnectionInProgress)
-    /// if any device is already in a transitional state.
+    /// if another task holds the connection mutex or this interface's device
+    /// is already connecting.
     pub async fn try_connect_to_bssid(
         &self,
         ssid: &str,
@@ -138,7 +140,7 @@ impl WifiScope {
             .connect_guard
             .try_lock()
             .map_err(|_| crate::ConnectionError::ConnectionInProgress)?;
-        if is_connecting(&self.conn).await? {
+        if is_connecting_on_interface(&self.conn, &self.interface).await? {
             return Err(crate::ConnectionError::ConnectionInProgress);
         }
         connect_to_bssid(

--- a/nmrs/src/core/device.rs
+++ b/nmrs/src/core/device.rs
@@ -10,6 +10,7 @@ use zbus::Connection;
 use crate::Result;
 use crate::api::models::{BluetoothDevice, ConnectionError, Device, DeviceIdentity, DeviceState};
 use crate::core::bluetooth::populate_bluez_info;
+use crate::core::connection::get_device_by_interface;
 use crate::core::state_wait::wait_for_wifi_device_ready;
 use crate::dbus::{NMBluetoothProxy, NMDeviceProxy, NMProxy};
 use crate::types::constants::device_type;
@@ -163,6 +164,33 @@ pub(crate) async fn is_connecting(conn: &Connection) -> Result<bool> {
     }
 
     Ok(false)
+}
+
+/// Returns `true` if the device with the given interface name is in a
+/// transitional state.
+///
+/// Returns `false` if no device matches the interface name.
+pub(crate) async fn is_connecting_on_interface(conn: &Connection, interface: &str) -> Result<bool> {
+    let path = match get_device_by_interface(conn, interface).await {
+        Ok(p) => p,
+        Err(ConnectionError::NotFound) => return Ok(false),
+        Err(e) => return Err(e),
+    };
+
+    let dev = NMDeviceProxy::builder(conn)
+        .path(path.clone())?
+        .build()
+        .await?;
+
+    let raw_state = dev
+        .state()
+        .await
+        .map_err(|e| ConnectionError::DbusOperation {
+            context: format!("failed to get state for device {}", path.as_str()),
+            source: e,
+        })?;
+
+    Ok(DeviceState::from(raw_state).is_transitional())
 }
 
 pub(crate) async fn list_bluetooth_devices(conn: &Connection) -> Result<Vec<BluetoothDevice>> {


### PR DESCRIPTION
This PR adds an internal `tokio::sync::Mutex` to NetworkManager and WifiScope that serializes all connection-mutating operations (connect, disconnect, VPN, Bluetooth, wired). Also introduces `try_connect`/`try_connect_to_bssid` methods that atomically check `is_connecting()` under the lock and return `ConnectionInProgress` when another operation is in flight.

Closes #352 