### PR TITLE
fix(#433): require EAP-TLS key and cert in builder

### DIFF
--- a/nmrs/src/api/models/tests.rs
+++ b/nmrs/src/api/models/tests.rs
@@ -970,6 +970,38 @@ fn test_eap_options_builder_tls() {
 }
 
 #[test]
+fn test_eap_options_builder_tls_missing_private_key() {
+    let err = EapOptions::builder()
+        .identity("student@university.edu")
+        .method(EapMethod::Tls)
+        .client_cert_path("file:///etc/ssl/certs/client.pem")
+        .build()
+        .unwrap_err();
+
+    match err {
+        ConnectionError::IncompleteBuilder(message) => assert!(message.contains("private key")),
+        err => panic!("expected IncompleteBuilder, got {err:?}"),
+    }
+}
+
+#[test]
+fn test_eap_options_builder_tls_missing_client_cert() {
+    let err = EapOptions::builder()
+        .identity("student@university.edu")
+        .method(EapMethod::Tls)
+        .private_key_path("file:///etc/ssl/private/client.key")
+        .build()
+        .unwrap_err();
+
+    match err {
+        ConnectionError::IncompleteBuilder(message) => {
+            assert!(message.contains("client certificate"));
+        }
+        err => panic!("expected IncompleteBuilder, got {err:?}"),
+    }
+}
+
+#[test]
 fn test_eap_options_builder_path_blob_ca_cert_path() {
     let opts = EapOptions::builder()
         .identity("student@university.edu")

--- a/nmrs/src/api/models/wifi.rs
+++ b/nmrs/src/api/models/wifi.rs
@@ -773,6 +773,18 @@ impl EapOptionsBuilder {
                 "EAP client certificate cannot be specified both as a path and blob".into(),
             ));
         }
+        if self.method == Some(EapMethod::Tls) {
+            if self.private_key_path.is_none() && self.private_key_blob.is_none() {
+                return Err(ConnectionError::IncompleteBuilder(
+                    "EAP private key is required for TLS (use .private_key_path() or .private_key_blob())".into(),
+                ));
+            }
+            if self.client_cert_path.is_none() && self.client_cert_blob.is_none() {
+                return Err(ConnectionError::IncompleteBuilder(
+                    "EAP client certificate is required for TLS (use .client_cert_path() or .client_cert_blob())".into(),
+                ));
+            }
+        }
 
         Ok(EapOptions {
             identity: self.identity.ok_or_else(|| {


### PR DESCRIPTION
- make `EapOptionsBuilder::build()` reject incomplete EAP-TLS configs
- require either `private_key_path` or `private_key_blob`
- require either `client_cert_path` or `client_cert_blob`
- add unit coverage for missing TLS private key and client certificate

This keeps the existing builder API unchanged and moves TLS required-field checks earlier, matching the builder docs.