### PR TITLE
feat: add wired device details API and secret-agent lifecycle docs

### DIFF
--- a/docs/src/api/models.md
+++ b/docs/src/api/models.md
@@ -19,6 +19,8 @@ pub struct Device {
     pub driver: Option<String>,
     pub ip4_address: Option<String>,
     pub ip6_address: Option<String>,
+    pub frequency: Option<u32>,       // active Wi-Fi frequency in MHz
+    pub speed_mbps: Option<u32>,      // Ethernet link speed in Mb/s
 }
 ```
 
@@ -122,6 +124,25 @@ pub struct WifiDevice {
     pub autoconnect: bool,
     pub is_active: bool,
     pub active_ssid: Option<String>,
+    pub active_frequency_mhz: Option<u32>,
+}
+```
+
+### WiredDevice
+
+An Ethernet device discovered by `list_wired_device_details()`.
+
+```rust
+pub struct WiredDevice {
+    pub path: String,
+    pub interface: String,                  // e.g. "eth0"
+    pub hw_address: String,                 // current MAC
+    pub permanent_hw_address: Option<String>,
+    pub speed_mbps: Option<u32>,            // raw NM link speed, may be 0
+    pub active_connection_id: Option<String>,
+    pub state: DeviceState,
+    pub ip4_address: Option<String>,
+    pub ip6_address: Option<String>,
 }
 ```
 

--- a/docs/src/api/network-manager.md
+++ b/docs/src/api/network-manager.md
@@ -105,6 +105,7 @@ let config = nm.timeout_config();
 | `list_devices()` | `Result<Vec<Device>>` | List all network devices |
 | `list_wireless_devices()` | `Result<Vec<Device>>` | List Wi-Fi devices |
 | `list_wired_devices()` | `Result<Vec<Device>>` | List Ethernet devices |
+| `list_wired_device_details()` | `Result<Vec<WiredDevice>>` | List Ethernet devices with link speed, active connection id, and IPs |
 | `get_device_by_interface(name)` | `Result<OwnedObjectPath>` | Find device by interface name |
 | `is_connecting()` | `Result<bool>` | Check if any device is connecting |
 

--- a/docs/src/guide/devices.md
+++ b/docs/src/guide/devices.md
@@ -35,6 +35,11 @@ Each device provides the following information:
 | `driver` | `Option<String>` | Kernel driver name |
 | `ip4_address` | `Option<String>` | IPv4 address with CIDR (when connected) |
 | `ip6_address` | `Option<String>` | IPv6 address with CIDR (when connected) |
+| `frequency` | `Option<u32>` | Active Wi-Fi frequency in MHz (Wi-Fi only) |
+| `speed_mbps` | `Option<u32>` | Raw Ethernet link speed in Mb/s (Ethernet only) |
+
+`speed_mbps` preserves NetworkManager's raw value. Some Ethernet drivers
+report `0` when no carrier is present.
 
 ## Device Types
 
@@ -88,6 +93,25 @@ dt.requires_specific_object();  // true for Wifi, WifiP2P
 dt.has_global_enabled_state();  // true for Wifi
 dt.connection_type_str();       // "802-11-wireless", "802-3-ethernet", etc.
 dt.to_code();                   // raw NM type code (2 for Wifi, 1 for Ethernet)
+```
+
+## Wired Details
+
+For Ethernet-specific UI rows, use `list_wired_device_details()` instead of
+falling back to raw D-Bus:
+
+```rust
+use nmrs::NetworkManager;
+
+let nm = NetworkManager::new().await?;
+
+for device in nm.list_wired_device_details().await? {
+    println!("{} {:?}", device.interface, device.state);
+    println!("  MAC: {}", device.hw_address);
+    println!("  speed: {:?}", device.speed_mbps);
+    println!("  connection: {:?}", device.active_connection_id);
+    println!("  IPv4: {:?}", device.ip4_address);
+}
 ```
 
 ## Device States

--- a/docs/src/guide/error-handling.md
+++ b/docs/src/guide/error-handling.md
@@ -92,6 +92,12 @@ most commonly handled variants by category.
 | `AgentNotRegistered` | Used a handle whose registration was already torn down |
 | `AgentAlreadyRegistered` | Secret agent registration conflict |
 
+For applet-style GUI code, register one secret agent during startup and keep
+the returned `SecretAgentHandle` alive for the application lifetime. If
+NetworkManager restarts, call `SecretAgentHandle::reregister()` after it is
+available again. Dropping or unregistering the handle stops credential prompts
+from reaching the app.
+
 ### Low-Level Errors
 
 | Variant | Description |

--- a/docs/src/guide/ethernet.md
+++ b/docs/src/guide/ethernet.md
@@ -43,11 +43,42 @@ async fn main() -> nmrs::Result<()> {
         if let Some(driver) = &device.driver {
             println!("  Driver: {}", driver);
         }
+        if let Some(speed) = device.speed_mbps {
+            println!("  Speed: {} Mb/s", speed);
+        }
     }
 
     Ok(())
 }
 ```
+
+For Ethernet-specific rows, `list_wired_device_details()` includes the raw
+NetworkManager link speed, active connection id, MAC addresses, state, and IP
+addresses:
+
+```rust
+use nmrs::NetworkManager;
+
+#[tokio::main]
+async fn main() -> nmrs::Result<()> {
+    let nm = NetworkManager::new().await?;
+
+    for device in nm.list_wired_device_details().await? {
+        println!("{} [{:?}]", device.interface, device.state);
+        println!("  MAC: {}", device.hw_address);
+        println!("  permanent MAC: {:?}", device.permanent_hw_address);
+        println!("  speed: {:?} Mb/s", device.speed_mbps);
+        println!("  active profile: {:?}", device.active_connection_id);
+        println!("  IPv4: {:?}", device.ip4_address);
+        println!("  IPv6: {:?}", device.ip6_address);
+    }
+
+    Ok(())
+}
+```
+
+`speed_mbps` preserves NetworkManager's raw value. Some drivers report `0`
+when no carrier is present.
 
 ## Errors
 

--- a/docs/src/guide/profiles.md
+++ b/docs/src/guide/profiles.md
@@ -70,6 +70,43 @@ nm.connect("HomeWiFi", None, WifiSecurity::WpaPsk {
 nm.connect("HomeWiFi", None, WifiSecurity::Open).await?;
 ```
 
+If a saved profile is missing or has stale secrets, NetworkManager may ask a
+registered secret agent for credentials during activation. GUI apps should
+register one long-lived agent at startup, keep the returned handle alive for
+the process lifetime, and re-register after NetworkManager restarts:
+
+```rust
+use futures::StreamExt;
+use nmrs::agent::{SecretAgent, SecretAgentFlags, SecretSetting};
+
+let (handle, mut requests) = SecretAgent::builder()
+    .with_identifier("com.system76.CosmicAppletNetwork")
+    .register()
+    .await?;
+
+tokio::spawn(async move {
+    while let Some(request) = requests.next().await {
+        if !request.flags.contains(SecretAgentFlags::ALLOW_INTERACTION) {
+            let _ = request.responder.no_secrets().await;
+            continue;
+        }
+
+        match request.setting {
+            SecretSetting::WifiPsk { ref ssid } => {
+                println!("prompt for password: {ssid}");
+                let _ = request.responder.cancel().await;
+            }
+            _ => {
+                let _ = request.responder.cancel().await;
+            }
+        }
+    }
+});
+
+// Keep `handle` alive while the applet is running.
+// Call `handle.reregister().await?` after NetworkManager restarts.
+```
+
 ## Forgetting (Deleting) Connections
 
 ### Wi-Fi Connections

--- a/nmrs/CHANGELOG.md
+++ b/nmrs/CHANGELOG.md
@@ -4,8 +4,19 @@ All notable changes to the `nmrs` crate will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `Device::speed_mbps` and `NetworkManager::list_wired_device_details()` expose
+  Ethernet link speed, active connection id, MAC addresses, state, and IPs for
+  wired-device UI rows. ([#454](https://github.com/networkmanager-rs/nmrs/pull/454))
+- Secret-agent lifecycle docs now recommend one long-lived applet registration,
+  keeping `SecretAgentHandle` alive, and calling
+  `SecretAgentHandle::reregister()` after NetworkManager restarts. ([#454](https://github.com/networkmanager-rs/nmrs/pull/454))
+
 ## [3.2.2] - 2026-06-30
+
 ### Fixed
+
 - `SecretAgent` now registers without owning a policy-controlled system bus
   name and serves the standard NetworkManager secret-agent object path, so
   credential prompts can reach the registered agent ([#451](https://github.com/networkmanager-rs/nmrs/issues/451))

--- a/nmrs/examples/secret_agent.rs
+++ b/nmrs/examples/secret_agent.rs
@@ -1,5 +1,6 @@
-/// Registers a NetworkManager secret agent, prints incoming requests,
-/// and responds to Wi-Fi PSK prompts by reading a password from stdin.
+/// Registers a long-lived NetworkManager secret agent, prints incoming
+/// requests, and responds to Wi-Fi PSK prompts by reading a password from
+/// stdin.
 ///
 /// Run with:
 ///
@@ -8,7 +9,7 @@
 /// ```
 ///
 /// Then trigger a password prompt (e.g. forget a saved Wi-Fi password and
-/// reconnect). The agent will print the request and ask for input.
+/// reconnect). The agent will print each request and ask for input.
 use std::io::{self, BufRead, Write};
 
 use futures::StreamExt;
@@ -22,9 +23,10 @@ async fn main() -> nmrs::Result<()> {
         .await?;
 
     println!("Secret agent registered. Waiting for requests…");
-    println!("(The agent will exit after processing one request)\n");
+    println!("Keep this process running while NetworkManager may need secrets.");
+    println!("After a NetworkManager restart, call SecretAgentHandle::reregister().\n");
 
-    if let Some(req) = requests.next().await {
+    while let Some(req) = requests.next().await {
         println!("── Secret request ──");
         println!("  UUID:    {}", req.connection_uuid);
         println!("  Name:    {}", req.connection_id);
@@ -61,6 +63,6 @@ async fn main() -> nmrs::Result<()> {
     }
 
     handle.unregister().await?;
-    println!("Agent unregistered.");
+    println!("Request stream closed; agent unregistered.");
     Ok(())
 }

--- a/nmrs/src/agent/builder.rs
+++ b/nmrs/src/agent/builder.rs
@@ -211,6 +211,10 @@ impl SecretAgentBuilder {
 ///
 /// Provides methods to re-register after a NetworkManager restart, access
 /// the cancellation and store-event streams, and shut the agent down.
+///
+/// GUI apps should keep this handle alive for as long as they want to answer
+/// NetworkManager credential prompts. Dropping the handle drops the D-Bus
+/// connection that serves the secret-agent object.
 pub struct SecretAgentHandle {
     conn: Connection,
     identifier: String,
@@ -234,7 +238,8 @@ impl SecretAgentHandle {
     ///
     /// Call this after detecting that NetworkManager restarted (e.g. its
     /// D-Bus name owner changed). The call is idempotent while the bus
-    /// connection is healthy.
+    /// connection is healthy. The same long-lived handle can be kept for the
+    /// process lifetime and re-registered whenever NetworkManager comes back.
     ///
     /// # Errors
     ///

--- a/nmrs/src/agent/mod.rs
+++ b/nmrs/src/agent/mod.rs
@@ -53,11 +53,57 @@
 //! well-known name. The agent object is served at NetworkManager's standard
 //! `/org/freedesktop/NetworkManager/SecretAgent` path by default.
 //!
+//! GUI apps should register one long-lived agent during application or applet
+//! startup and keep the returned [`SecretAgentHandle`](crate::agent::SecretAgentHandle)
+//! alive for the process lifetime. Dropping or unregistering the handle tears
+//! down the registration and closes the request stream.
+//!
 //! If NetworkManager restarts while the agent is running, call
 //! [`SecretAgentHandle::reregister()`](crate::agent::SecretAgentHandle::reregister)
-//! to re-register.
+//! after detecting that NetworkManager is available again.
 //!
 //! # Example
+//!
+//! ```no_run
+//! use futures::StreamExt;
+//! use nmrs::agent::{SecretAgent, SecretAgentFlags, SecretSetting};
+//!
+//! # async fn run() -> nmrs::Result<()> {
+//! let (handle, mut requests) = SecretAgent::builder()
+//!     .with_identifier("com.example.demo")
+//!     .register()
+//!     .await?;
+//!
+//! let request_task = tokio::spawn(async move {
+//!     while let Some(req) = requests.next().await {
+//!         if !req.flags.contains(SecretAgentFlags::ALLOW_INTERACTION) {
+//!             req.responder.no_secrets().await?;
+//!             continue;
+//!         }
+//!
+//!         match req.setting {
+//!             SecretSetting::WifiPsk { ref ssid } => {
+//!                 println!("Password needed for {ssid}");
+//!                 req.responder.wifi_psk("secret").await?;
+//!             }
+//!             _ => req.responder.cancel().await?,
+//!         }
+//!     }
+//!
+//!     Ok::<(), nmrs::ConnectionError>(())
+//! });
+//!
+//! // Keep `handle` alive for as long as the app should answer prompts.
+//! // After a NetworkManager restart, call:
+//! // handle.reregister().await?;
+//!
+//! request_task.abort();
+//! handle.unregister().await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! A foreground loop works too:
 //!
 //! ```no_run
 //! use futures::StreamExt;

--- a/nmrs/src/api/models/device.rs
+++ b/nmrs/src/api/models/device.rs
@@ -61,8 +61,11 @@ pub struct Device {
     pub ip6_address: Option<String>,
     /// Operating frequency in MHz for the active Wi-Fi connection, if known.
     pub frequency: Option<u32>,
-    // Link speed in Mb/s (wired devices)
-    // pub speed: Option<u32>,
+    /// Link speed in megabits per second for Ethernet devices, if known.
+    ///
+    /// This is the raw value reported by NetworkManager. Some drivers report
+    /// `0` when no carrier is present.
+    pub speed_mbps: Option<u32>,
 }
 
 /// A Wi-Fi device summary returned by
@@ -98,6 +101,38 @@ pub struct WifiDevice {
     pub active_ssid: Option<String>,
     /// Operating frequency in MHz of the currently active AP, if any.
     pub active_frequency_mhz: Option<u32>,
+}
+
+/// A wired Ethernet device summary returned by
+/// [`list_wired_device_details`](crate::NetworkManager::list_wired_device_details).
+///
+/// Use this when Ethernet-specific details such as link speed, hardware
+/// address, or active connection id are needed without falling back to raw
+/// D-Bus calls.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct WiredDevice {
+    /// D-Bus object path of the device.
+    pub path: String,
+    /// Interface name (e.g. `"eth0"`).
+    pub interface: String,
+    /// Current MAC address.
+    pub hw_address: String,
+    /// Permanent (factory-burned) MAC, if NM exposes it.
+    pub permanent_hw_address: Option<String>,
+    /// Link speed in megabits per second, if NM exposes it.
+    ///
+    /// This is the raw NetworkManager value. Some drivers report `0` when no
+    /// carrier is present.
+    pub speed_mbps: Option<u32>,
+    /// Active connection profile id, if this device is connected.
+    pub active_connection_id: Option<String>,
+    /// Current device state.
+    pub state: DeviceState,
+    /// Assigned IPv4 address with CIDR notation, if connected.
+    pub ip4_address: Option<String>,
+    /// Assigned IPv6 address with CIDR notation, if connected.
+    pub ip6_address: Option<String>,
 }
 
 /// Represents the hardware identity of a network device.

--- a/nmrs/src/api/models/tests.rs
+++ b/nmrs/src/api/models/tests.rs
@@ -604,11 +604,54 @@ fn test_device_is_bluetooth() {
         ip4_address: None,
         ip6_address: None,
         frequency: None,
+        speed_mbps: None,
     };
 
     assert!(bt_device.is_bluetooth());
     assert!(!bt_device.is_wireless());
     assert!(!bt_device.is_wired());
+}
+
+#[test]
+fn test_device_wired_speed_construction() {
+    let device = Device {
+        path: "/org/freedesktop/NetworkManager/Devices/2".into(),
+        interface: "eth0".into(),
+        identity: DeviceIdentity::new("00:11:22:33:44:55".into(), "00:11:22:33:44:55".into()),
+        device_type: DeviceType::Ethernet,
+        state: DeviceState::Activated,
+        managed: Some(true),
+        driver: Some("e1000e".into()),
+        ip4_address: Some("192.0.2.10/24".into()),
+        ip6_address: None,
+        frequency: None,
+        speed_mbps: Some(1000),
+    };
+
+    assert!(device.is_wired());
+    assert_eq!(device.speed_mbps, Some(1000));
+}
+
+#[test]
+fn test_wired_device_construction() {
+    let device = WiredDevice {
+        path: "/org/freedesktop/NetworkManager/Devices/2".into(),
+        interface: "eth0".into(),
+        hw_address: "00:11:22:33:44:55".into(),
+        permanent_hw_address: Some("00:11:22:33:44:55".into()),
+        speed_mbps: Some(0),
+        active_connection_id: Some("Wired connection 1".into()),
+        state: DeviceState::Disconnected,
+        ip4_address: None,
+        ip6_address: None,
+    };
+
+    assert_eq!(device.interface, "eth0");
+    assert_eq!(device.speed_mbps, Some(0));
+    assert_eq!(
+        device.active_connection_id.as_deref(),
+        Some("Wired connection 1")
+    );
 }
 
 #[test]

--- a/nmrs/src/api/network_manager.rs
+++ b/nmrs/src/api/network_manager.rs
@@ -9,7 +9,7 @@ use crate::Result;
 use crate::api::models::access_point::AccessPoint;
 use crate::api::models::{
     AirplaneModeState, Device, Network, NetworkInfo, RadioState, SavedConnection,
-    SavedConnectionBrief, SettingsPatch, WifiDevice, WifiSecurity,
+    SavedConnectionBrief, SettingsPatch, WifiDevice, WifiSecurity, WiredDevice,
 };
 use crate::api::wifi_scope::WifiScope;
 use crate::core::airplane;
@@ -22,7 +22,8 @@ use crate::core::connection_settings::{
     get_saved_connection_path, get_saved_connection_uuid, has_saved_connection,
 };
 use crate::core::device::{
-    is_connecting, list_bluetooth_devices, list_devices, wait_for_wifi_ready,
+    is_connecting, list_bluetooth_devices, list_devices, list_wired_device_details,
+    wait_for_wifi_ready,
 };
 use crate::core::saved_connection as saved_profiles;
 use crate::core::scan::{current_network, list_access_points, list_networks, scan_networks};
@@ -245,6 +246,15 @@ impl NetworkManager {
     pub async fn list_wired_devices(&self) -> Result<Vec<Device>> {
         let devices = list_devices(&self.conn).await?;
         Ok(devices.into_iter().filter(|d| d.is_wired()).collect())
+    }
+
+    /// List wired (Ethernet) devices with Ethernet-specific details.
+    ///
+    /// Each [`WiredDevice`] includes the interface name, current and permanent
+    /// MAC addresses, raw NetworkManager link speed, active connection id, and
+    /// assigned IP addresses when connected.
+    pub async fn list_wired_device_details(&self) -> Result<Vec<WiredDevice>> {
+        list_wired_device_details(&self.conn).await
     }
 
     /// Lists all visible Wi-Fi networks.

--- a/nmrs/src/core/device.rs
+++ b/nmrs/src/core/device.rs
@@ -8,11 +8,16 @@ use log::{debug, warn};
 use zbus::Connection;
 
 use crate::Result;
-use crate::api::models::{BluetoothDevice, ConnectionError, Device, DeviceIdentity, DeviceState};
+use crate::api::models::{
+    BluetoothDevice, ConnectionError, Device, DeviceIdentity, DeviceState, WiredDevice,
+};
 use crate::core::bluetooth::populate_bluez_info;
 use crate::core::connection::get_device_by_interface;
 use crate::core::state_wait::wait_for_wifi_device_ready;
-use crate::dbus::{NMAccessPointProxy, NMBluetoothProxy, NMDeviceProxy, NMProxy, NMWirelessProxy};
+use crate::dbus::{
+    NMAccessPointProxy, NMActiveConnectionProxy, NMBluetoothProxy, NMDeviceProxy, NMProxy,
+    NMWiredProxy, NMWirelessProxy,
+};
 use crate::types::constants::device_type;
 use crate::util::utils::get_ip_addresses_from_active_connection;
 
@@ -141,9 +146,7 @@ pub(crate) async fn list_devices(conn: &Connection) -> Result<Vec<Device>> {
                 (None, None)
             };
 
-        // Avoiding this breaking change for now
-        // Get link speed for wired devices
-        /* let speed = if raw_type == device_type::ETHERNET {
+        let speed_mbps = if raw_type == device_type::ETHERNET {
             async {
                 let wired = NMWiredProxy::builder(conn).path(p.clone())?.build().await?;
                 wired.speed().await
@@ -152,7 +155,8 @@ pub(crate) async fn list_devices(conn: &Connection) -> Result<Vec<Device>> {
             .ok()
         } else {
             None
-        };*/
+        };
+
         devices.push(Device {
             path: p.to_string(),
             interface,
@@ -164,9 +168,97 @@ pub(crate) async fn list_devices(conn: &Connection) -> Result<Vec<Device>> {
             ip4_address,
             ip6_address,
             frequency,
-            // speed,
+            speed_mbps,
         });
     }
+    Ok(devices)
+}
+
+/// Lists wired Ethernet devices with Ethernet-specific details.
+pub(crate) async fn list_wired_device_details(conn: &Connection) -> Result<Vec<WiredDevice>> {
+    let proxy = NMProxy::new(conn).await?;
+    let paths = proxy
+        .get_devices()
+        .await
+        .map_err(|e| ConnectionError::DbusOperation {
+            context: "failed to get device paths from NetworkManager".to_string(),
+            source: e,
+        })?;
+
+    let mut devices = Vec::new();
+    for p in paths {
+        let d_proxy = NMDeviceProxy::builder(conn)
+            .path(p.clone())?
+            .build()
+            .await?;
+
+        if d_proxy.device_type().await? != device_type::ETHERNET {
+            continue;
+        }
+
+        let interface = d_proxy
+            .interface()
+            .await
+            .map_err(|e| ConnectionError::DbusOperation {
+                context: format!("failed to get interface name for device {}", p.as_str()),
+                source: e,
+            })?;
+        // Some virtual or unusual devices omit HwAddress; keep the row usable.
+        let hw_address = d_proxy
+            .hw_address()
+            .await
+            .unwrap_or_else(|_| String::from("00:00:00:00:00:00"));
+        let permanent_hw_address = d_proxy
+            .perm_hw_address()
+            .await
+            .ok()
+            .filter(|addr| !addr.is_empty());
+        let state = d_proxy.state().await?.into();
+
+        let speed_mbps = async {
+            let wired = NMWiredProxy::builder(conn).path(p.clone())?.build().await?;
+            wired.speed().await
+        }
+        .await
+        .ok();
+
+        let active_conn_path = d_proxy.active_connection().await.ok();
+        let active_connection_id = match active_conn_path.as_ref() {
+            Some(path) if path.as_str() != "/" => {
+                async {
+                    let active = NMActiveConnectionProxy::builder(conn)
+                        .path(path.clone())
+                        .ok()?
+                        .build()
+                        .await
+                        .ok()?;
+                    active.id().await.ok()
+                }
+                .await
+            }
+            _ => None,
+        };
+
+        let (ip4_address, ip6_address) = match active_conn_path.as_ref() {
+            Some(path) if path.as_str() != "/" => {
+                get_ip_addresses_from_active_connection(conn, path).await
+            }
+            _ => (None, None),
+        };
+
+        devices.push(WiredDevice {
+            path: p.to_string(),
+            interface,
+            hw_address,
+            permanent_hw_address,
+            speed_mbps,
+            active_connection_id,
+            state,
+            ip4_address,
+            ip6_address,
+        });
+    }
+
     Ok(devices)
 }
 

--- a/nmrs/src/lib.rs
+++ b/nmrs/src/lib.rs
@@ -360,6 +360,7 @@ pub mod builders {
 /// - [`AccessPoint`] — Per-BSSID access point details
 /// - [`NetworkInfo`] — Detailed network information returned by `show_details`
 /// - [`WifiDevice`] — Wi-Fi-specific device summary
+/// - [`WiredDevice`] — Ethernet-specific device summary
 /// - [`BluetoothDevice`] — Discovered Bluetooth peer
 /// - [`SavedConnection`] / [`SavedConnectionBrief`] — Saved profile snapshots
 /// - [`SettingsSummary`] / [`SettingsPatch`] — Decoded NM settings & update patches
@@ -416,7 +417,7 @@ pub use api::models::{
     SavedConnectionBrief, SecurityFeatures, SettingsPatch, SettingsSummary, StateReason,
     TimeoutConfig, VlanConfig, VpnConfig, VpnConfiguration, VpnConnection, VpnConnectionInfo,
     VpnCredentials, VpnDetails, VpnKind, VpnRoute, VpnSecretFlags, VpnType, WifiDevice,
-    WifiKeyMgmt, WifiSecurity, WifiSecuritySummary, WireGuardConfig, WireGuardPeer,
+    WifiKeyMgmt, WifiSecurity, WifiSecuritySummary, WireGuardConfig, WireGuardPeer, WiredDevice,
     connection_state_reason_to_error, reason_to_error,
 };
 pub use api::network_manager::NetworkManager;


### PR DESCRIPTION
Adds Ethernet link speed to `Device` and introduces `WiredDevice` with `NetworkManager::list_wired_device_details()` for applet wired rows that need MACs, active connection id, state, speed, and IP addresses without raw D-Bus fallbacks.

Also documents the intended secret-agent lifecycle for GUI apps: register one long-lived agent at startup, keep the handle alive, and call `SecretAgentHandle::reregister()` after NetworkManager restarts.