### PR TITLE
feat: add Wi-Fi UX snapshot helpers

### DIFF
--- a/docs/src/api/models.md
+++ b/docs/src/api/models.md
@@ -175,6 +175,62 @@ pub struct NetworkSnapshot {
 }
 ```
 
+Helper methods on `NetworkSnapshot` provide applet-ready views without extra
+D-Bus reads:
+
+```rust
+let snapshot = nm.snapshot().await?;
+let groups = snapshot.wifi_groups();
+let known_wifi = snapshot.known_wifi_by_ssid();
+let saved_vpns = snapshot.saved_vpn_map();
+let applet = snapshot.applet_summary();
+```
+
+`wifi_groups()` groups access points by `(interface, ssid)`, keeps every BSSID,
+marks known networks from matching saved profiles, and marks the active group
+from typed active Wi-Fi connections.
+
+### WifiNetworkGroup
+
+```rust
+pub struct WifiNetworkGroup {
+    pub ssid: String,
+    pub interface: String,
+    pub strongest: AccessPoint,
+    pub access_points: Vec<AccessPoint>,
+    pub saved_profiles: Vec<SavedConnectionBrief>,
+    pub active: bool,
+    pub known: bool,
+}
+```
+
+### AppletNetworkSummary
+
+```rust
+pub struct AppletNetworkSummary {
+    pub active_connections: Vec<ActiveConnection>,
+    pub wifi_groups: Vec<WifiNetworkGroup>,
+    pub known_wifi: HashMap<String, Vec<SavedConnectionBrief>>,
+    pub saved_vpns: HashMap<String, SavedVpnSummary>,
+    pub connectivity: ConnectivityReport,
+    pub airplane_mode: AirplaneModeState,
+}
+```
+
+### SavedVpnSummary
+
+Saved VPN summaries returned by `NetworkSnapshot::saved_vpn_map()`, keyed by
+UUID.
+
+```rust
+pub struct SavedVpnSummary {
+    pub uuid: String,
+    pub id: String,
+    pub kind: Option<VpnKind>,
+    pub active: bool,
+}
+```
+
 ### ActiveConnection
 
 Typed active connections returned by `list_active_connections()` and nested in

--- a/docs/src/api/types.md
+++ b/docs/src/api/types.md
@@ -82,6 +82,9 @@ All public methods return `nmrs::Result<T>`.
 |------|-------------|
 | `ConnectivityState` | NM connectivity: `Full`, `Portal`, `Limited`, `None`, `Unknown` |
 | `ConnectivityReport` | Full report with state, check URI, and captive portal URL |
+| `NetworkSnapshot` | Point-in-time applet state |
+| `AppletNetworkSummary` | Applet-ready summary derived from a snapshot |
+| `WifiNetworkGroup` | Visible APs grouped by interface and SSID |
 
 ## Saved Connection Types
 
@@ -89,6 +92,7 @@ All public methods return `nmrs::Result<T>`.
 |------|-------------|
 | `SavedConnection` | Full decoded saved profile |
 | `SavedConnectionBrief` | Lightweight profile (`uuid`, `id`, `type`) |
+| `SavedVpnSummary` | Lightweight saved VPN status keyed by UUID |
 | `SettingsSummary` | Decoded settings within a profile |
 | `SettingsPatch` | Partial update for `update_saved_connection` |
 

--- a/docs/src/examples/connection-manager.md
+++ b/docs/src/examples/connection-manager.md
@@ -186,6 +186,31 @@ fn read_line() -> String {
 }
 ```
 
+## Snapshot Helpers
+
+GUI connection managers can refresh from one snapshot and derive applet-ready
+rows without extra D-Bus calls:
+
+```rust
+let snapshot = nm.snapshot().await?;
+let summary = snapshot.applet_summary();
+
+for group in &summary.wifi_groups {
+    println!(
+        "{} on {}: {}% known={} active={}",
+        group.ssid,
+        group.interface,
+        group.strongest.strength,
+        group.known,
+        group.active,
+    );
+}
+
+for vpn in summary.saved_vpns.values() {
+    println!("{} active={}", vpn.id, vpn.active);
+}
+```
+
 ## Running
 
 ```bash

--- a/docs/src/guide/wifi-per-device.md
+++ b/docs/src/guide/wifi-per-device.md
@@ -95,14 +95,43 @@ When the same SSID is broadcast by multiple access points, use `connect_to_bssid
 let scope = nm.wifi("wlan0");
 
 let aps = scope.list_access_points().await?;
-if let Some(best) = aps.iter().max_by_key(|ap| ap.strength.unwrap_or(0)) {
+if let Some(best) = aps.iter().max_by_key(|ap| ap.strength) {
     scope.connect_to_bssid(
         &best.ssid,
-        &best.hwaddress.as_deref().unwrap_or_default(),
+        &best.bssid,
         WifiSecurity::WpaPsk { psk: "password".into() },
     ).await?;
 }
 ```
+
+## Snapshot Wi-Fi Groups
+
+For applet-style UIs, `NetworkSnapshot::wifi_groups()` groups visible APs by
+`(interface, ssid)`. This keeps duplicate SSIDs on different radios separate,
+preserves every BSSID in the group, and attaches matching saved profiles.
+
+```rust
+let snapshot = nm.snapshot().await?;
+
+for group in snapshot.wifi_groups() {
+    println!(
+        "{} on {}: {}% active={} known={}",
+        group.ssid,
+        group.interface,
+        group.strongest.strength,
+        group.active,
+        group.known,
+    );
+
+    for ap in &group.access_points {
+        println!("  {} {} MHz", ap.bssid, ap.frequency_mhz);
+    }
+}
+```
+
+Saved profile matching respects optional `connection.interface-name` bindings
+and saved BSSID pins, so the same SSID can appear independently on multiple
+radios without being collapsed into one UI row.
 
 ## Per-Interface vs Global Operations
 

--- a/nmrs/CHANGELOG.md
+++ b/nmrs/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to the `nmrs` crate will be documented in this file.
 - `NetworkSnapshot`, typed `ActiveConnection` models,
   `NetworkManager::snapshot()`, and `NetworkManager::list_active_connections()`
   provide point-in-time state reads for applet refreshes after `NetworkEvent`. ([#456](https://github.com/networkmanager-rs/nmrs/pull/456))
+- `NetworkSnapshot::wifi_groups()`, `known_wifi_by_ssid()`, `saved_vpn_map()`,
+  and `applet_summary()` derive applet-ready Wi-Fi and VPN rows from snapshot
+  data without additional D-Bus calls. ([#458](https://github.com/networkmanager-rs/nmrs/pull/458))
 - Secret-agent lifecycle docs now recommend one long-lived applet registration,
   keeping `SecretAgentHandle` alive, and calling
   `SecretAgentHandle::reregister()` after NetworkManager restarts. ([#454](https://github.com/networkmanager-rs/nmrs/pull/454))

--- a/nmrs/src/api/models/mod.rs
+++ b/nmrs/src/api/models/mod.rs
@@ -33,7 +33,7 @@ pub use network_event::*;
 pub use openvpn::*;
 pub use radio::*;
 pub use saved_connection::*;
-pub use snapshot::NetworkSnapshot;
+pub use snapshot::{AppletNetworkSummary, NetworkSnapshot};
 pub use state_reason::*;
 pub use vlan::*;
 pub use vpn::*;

--- a/nmrs/src/api/models/snapshot.rs
+++ b/nmrs/src/api/models/snapshot.rs
@@ -1,9 +1,34 @@
 //! Point-in-time NetworkManager snapshot model.
 
+use std::collections::HashMap;
+
 use super::{
     AccessPoint, ActiveConnection, AirplaneModeState, ConnectivityReport, Device, RadioState,
-    SavedConnection, WifiDevice,
+    SavedConnection, SavedConnectionBrief, SavedVpnSummary, SettingsSummary, VpnKind, WifiDevice,
+    WifiNetworkGroup,
 };
+
+/// Applet-oriented view derived from a [`NetworkSnapshot`].
+///
+/// This summary groups visible Wi-Fi APs, indexes saved Wi-Fi profiles by SSID,
+/// and indexes saved VPN profiles by UUID. It is a pure transformation of the
+/// snapshot and performs no D-Bus reads.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct AppletNetworkSummary {
+    /// Active connections classified for applet rendering.
+    pub active_connections: Vec<ActiveConnection>,
+    /// Visible Wi-Fi groups keyed by interface and SSID.
+    pub wifi_groups: Vec<WifiNetworkGroup>,
+    /// Saved Wi-Fi profiles keyed by SSID.
+    pub known_wifi: HashMap<String, Vec<SavedConnectionBrief>>,
+    /// Saved VPN profiles keyed by UUID.
+    pub saved_vpns: HashMap<String, SavedVpnSummary>,
+    /// Connectivity and captive-portal state.
+    pub connectivity: ConnectivityReport,
+    /// Aggregated airplane-mode state.
+    pub airplane_mode: AirplaneModeState,
+}
 
 /// Point-in-time state needed by GUI network applets.
 ///
@@ -38,18 +63,269 @@ pub struct NetworkSnapshot {
     pub wired_devices: Vec<Device>,
 }
 
+impl NetworkSnapshot {
+    /// Groups visible access points by `(interface, ssid)` for applet Wi-Fi rows.
+    ///
+    /// Each group keeps every BSSID for advanced UI behavior and exposes the
+    /// strongest AP as the representative row. Matching saved profiles are
+    /// attached when their SSID, optional interface binding, and optional BSSID
+    /// binding match the visible group.
+    #[must_use]
+    pub fn wifi_groups(&self) -> Vec<WifiNetworkGroup> {
+        let mut grouped: HashMap<(String, String), Vec<AccessPoint>> = HashMap::new();
+        for ap in &self.access_points {
+            grouped
+                .entry((ap.interface.clone(), ap.ssid.clone()))
+                .or_default()
+                .push(ap.clone());
+        }
+
+        let mut groups = grouped
+            .into_iter()
+            .filter_map(|((interface, ssid), mut access_points)| {
+                sort_access_points(&mut access_points, &self.active_connections, &interface);
+                let strongest = access_points.first()?.clone();
+                let saved_profiles = self
+                    .saved_wifi_profiles
+                    .iter()
+                    .filter(|profile| {
+                        saved_wifi_matches_group(profile, &interface, &ssid, &access_points)
+                    })
+                    .map(saved_brief)
+                    .collect::<Vec<_>>();
+                let active = active_wifi_matches_group(
+                    &self.active_connections,
+                    &interface,
+                    &ssid,
+                    &access_points,
+                );
+                let known = !saved_profiles.is_empty();
+
+                Some(WifiNetworkGroup {
+                    ssid,
+                    interface,
+                    strongest,
+                    access_points,
+                    saved_profiles,
+                    active,
+                    known,
+                })
+            })
+            .collect::<Vec<_>>();
+
+        groups.sort_by(|a, b| {
+            a.interface
+                .cmp(&b.interface)
+                .then_with(|| a.ssid.cmp(&b.ssid))
+        });
+        groups
+    }
+
+    /// Returns saved Wi-Fi profiles keyed by SSID.
+    ///
+    /// Duplicate profiles for the same SSID are preserved. Hidden profiles are
+    /// included when their saved settings contain an SSID, even if no visible AP
+    /// appears in this snapshot.
+    #[must_use]
+    pub fn known_wifi_by_ssid(&self) -> HashMap<String, Vec<SavedConnectionBrief>> {
+        let mut known: HashMap<String, Vec<SavedConnectionBrief>> = HashMap::new();
+        for profile in &self.saved_wifi_profiles {
+            if let Some(ssid) = saved_wifi_ssid(profile) {
+                known
+                    .entry(ssid.to_string())
+                    .or_default()
+                    .push(saved_brief(profile));
+            }
+        }
+        known
+    }
+
+    /// Returns saved VPN profiles keyed by UUID.
+    ///
+    /// Both NetworkManager plugin VPNs and native WireGuard profiles are
+    /// included. A summary is marked active when a typed active VPN connection
+    /// has the same UUID.
+    #[must_use]
+    pub fn saved_vpn_map(&self) -> HashMap<String, SavedVpnSummary> {
+        let mut vpns = HashMap::new();
+        for profile in &self.saved_vpn_profiles {
+            if !is_saved_vpn_profile(profile) {
+                continue;
+            }
+
+            let active = self.active_connections.iter().any(|connection| {
+                matches!(connection, ActiveConnection::Vpn(vpn) if vpn.uuid == profile.uuid)
+            });
+            let summary = SavedVpnSummary {
+                uuid: profile.uuid.clone(),
+                id: profile.id.clone(),
+                kind: saved_vpn_kind(profile),
+                active,
+            };
+            vpns.insert(summary.uuid.clone(), summary);
+        }
+        vpns
+    }
+
+    /// Builds an applet-oriented summary from this snapshot.
+    ///
+    /// This is equivalent to calling [`Self::wifi_groups`],
+    /// [`Self::known_wifi_by_ssid`], and [`Self::saved_vpn_map`] on the same
+    /// snapshot and bundling the results with active connection, connectivity,
+    /// and airplane-mode state.
+    #[must_use]
+    pub fn applet_summary(&self) -> AppletNetworkSummary {
+        AppletNetworkSummary {
+            active_connections: self.active_connections.clone(),
+            wifi_groups: self.wifi_groups(),
+            known_wifi: self.known_wifi_by_ssid(),
+            saved_vpns: self.saved_vpn_map(),
+            connectivity: self.connectivity.clone(),
+            airplane_mode: self.airplane_mode,
+        }
+    }
+}
+
 pub(crate) fn saved_wifi_profiles(saved: &[SavedConnection]) -> Vec<SavedConnection> {
     saved
         .iter()
-        .filter(|profile| profile.connection_type == "802-11-wireless")
+        .filter(|profile| saved_wifi_ssid(profile).is_some())
         .cloned()
         .collect()
+}
+
+fn sort_access_points(
+    access_points: &mut [AccessPoint],
+    active_connections: &[ActiveConnection],
+    interface: &str,
+) {
+    access_points.sort_by(|a, b| {
+        b.strength
+            .cmp(&a.strength)
+            .then_with(|| {
+                let a_active = ap_matches_active_bssid(a, active_connections, interface);
+                let b_active = ap_matches_active_bssid(b, active_connections, interface);
+                b_active.cmp(&a_active)
+            })
+            .then_with(|| a.bssid.cmp(&b.bssid))
+    });
+}
+
+fn ap_matches_active_bssid(
+    ap: &AccessPoint,
+    active_connections: &[ActiveConnection],
+    interface: &str,
+) -> bool {
+    ap.is_active
+        || active_connections.iter().any(|connection| {
+            let ActiveConnection::Wifi(active) = connection else {
+                return false;
+            };
+            active.interface.as_deref() == Some(interface)
+                && active
+                    .bssid
+                    .as_deref()
+                    .is_some_and(|bssid| bssid_eq(&ap.bssid, bssid))
+        })
+}
+
+fn active_wifi_matches_group(
+    active_connections: &[ActiveConnection],
+    interface: &str,
+    ssid: &str,
+    access_points: &[AccessPoint],
+) -> bool {
+    active_connections.iter().any(|connection| {
+        let ActiveConnection::Wifi(active) = connection else {
+            return false;
+        };
+        if active.interface.as_deref() != Some(interface) {
+            return false;
+        }
+        active.ssid == ssid
+            || active
+                .bssid
+                .as_deref()
+                .is_some_and(|bssid| access_points.iter().any(|ap| bssid_eq(&ap.bssid, bssid)))
+    })
+}
+
+fn saved_wifi_matches_group(
+    profile: &SavedConnection,
+    interface: &str,
+    ssid: &str,
+    access_points: &[AccessPoint],
+) -> bool {
+    if saved_wifi_ssid(profile) != Some(ssid) {
+        return false;
+    }
+    if let Some(bound_interface) = profile.interface_name.as_deref()
+        && !bound_interface.is_empty()
+        && bound_interface != interface
+    {
+        return false;
+    }
+    if let Some(bssid) = saved_wifi_bssid(profile) {
+        return access_points.iter().any(|ap| bssid_eq(&ap.bssid, bssid));
+    }
+    true
+}
+
+fn saved_wifi_ssid(profile: &SavedConnection) -> Option<&str> {
+    if profile.connection_type != "802-11-wireless" {
+        return None;
+    }
+    match &profile.summary {
+        SettingsSummary::Wifi { ssid, .. } => Some(ssid.as_str()),
+        _ => None,
+    }
+}
+
+fn saved_wifi_bssid(profile: &SavedConnection) -> Option<&str> {
+    match &profile.summary {
+        SettingsSummary::Wifi { bssid, .. } => bssid
+            .as_deref()
+            .filter(|saved_bssid| !saved_bssid.is_empty()),
+        _ => None,
+    }
+}
+
+fn saved_brief(profile: &SavedConnection) -> SavedConnectionBrief {
+    SavedConnectionBrief {
+        path: profile.path.clone(),
+        uuid: profile.uuid.clone(),
+        id: profile.id.clone(),
+        connection_type: profile.connection_type.clone(),
+    }
+}
+
+fn is_saved_vpn_profile(profile: &SavedConnection) -> bool {
+    matches!(profile.connection_type.as_str(), "vpn" | "wireguard")
+        || matches!(&profile.summary, SettingsSummary::WireGuard { .. })
+}
+
+fn saved_vpn_kind(profile: &SavedConnection) -> Option<VpnKind> {
+    if profile.connection_type == "wireguard"
+        || matches!(&profile.summary, SettingsSummary::WireGuard { .. })
+    {
+        Some(VpnKind::WireGuard)
+    } else if profile.connection_type == "vpn"
+        || matches!(&profile.summary, SettingsSummary::Vpn { .. })
+    {
+        Some(VpnKind::Plugin)
+    } else {
+        None
+    }
+}
+
+fn bssid_eq(left: &str, right: &str) -> bool {
+    left.eq_ignore_ascii_case(right)
 }
 
 pub(crate) fn saved_vpn_profiles(saved: &[SavedConnection]) -> Vec<SavedConnection> {
     saved
         .iter()
-        .filter(|profile| matches!(profile.connection_type.as_str(), "vpn" | "wireguard"))
+        .filter(|profile| is_saved_vpn_profile(profile))
         .cloned()
         .collect()
 }
@@ -57,7 +333,10 @@ pub(crate) fn saved_vpn_profiles(saved: &[SavedConnection]) -> Vec<SavedConnecti
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::models::SettingsSummary;
+    use crate::api::models::{
+        ActiveConnectionState, ActiveVpnConnection, ActiveWifiConnection, ApMode,
+        ConnectivityState, DeviceState, SecurityFeatures, VpnSecretFlags,
+    };
     use zvariant::OwnedObjectPath;
 
     fn saved(connection_type: &str) -> SavedConnection {
@@ -80,10 +359,169 @@ mod tests {
         }
     }
 
+    fn object_path(path: &str) -> OwnedObjectPath {
+        OwnedObjectPath::try_from(path).expect("valid object path")
+    }
+
+    fn snapshot(
+        access_points: Vec<AccessPoint>,
+        saved_wifi_profiles: Vec<SavedConnection>,
+        saved_vpn_profiles: Vec<SavedConnection>,
+        active_connections: Vec<ActiveConnection>,
+    ) -> NetworkSnapshot {
+        let radio = RadioState::with_presence(false, true, false);
+        NetworkSnapshot {
+            wifi: radio,
+            wwan: radio,
+            bluetooth: radio,
+            airplane_mode: AirplaneModeState::new(radio, radio, radio),
+            connectivity: ConnectivityReport {
+                state: ConnectivityState::Unknown,
+                check_enabled: false,
+                check_uri: None,
+                captive_portal_url: None,
+            },
+            active_connections,
+            access_points,
+            saved_connections: Vec::new(),
+            saved_wifi_profiles,
+            saved_vpn_profiles,
+            wifi_devices: Vec::new(),
+            wired_devices: Vec::new(),
+        }
+    }
+
+    fn ap(interface: &str, ssid: &str, bssid: &str, strength: u8) -> AccessPoint {
+        AccessPoint {
+            path: object_path(&format!(
+                "/org/freedesktop/NetworkManager/AccessPoint/{}",
+                bssid.replace(':', "")
+            )),
+            device_path: object_path(&format!(
+                "/org/freedesktop/NetworkManager/Devices/{interface}"
+            )),
+            interface: interface.to_string(),
+            ssid: ssid.to_string(),
+            ssid_bytes: ssid.as_bytes().to_vec(),
+            bssid: bssid.to_string(),
+            frequency_mhz: 2412,
+            max_bitrate_kbps: 54000,
+            strength,
+            mode: ApMode::Infrastructure,
+            security: SecurityFeatures::default(),
+            last_seen_secs: None,
+            is_active: false,
+            device_state: DeviceState::Disconnected,
+        }
+    }
+
+    fn saved_wifi(
+        index: usize,
+        uuid: &str,
+        ssid: &str,
+        interface_name: Option<&str>,
+        bssid: Option<&str>,
+    ) -> SavedConnection {
+        SavedConnection {
+            path: object_path(&format!("/org/freedesktop/NetworkManager/Settings/{index}")),
+            uuid: uuid.to_string(),
+            id: ssid.to_string(),
+            connection_type: "802-11-wireless".to_string(),
+            interface_name: interface_name.map(ToOwned::to_owned),
+            autoconnect: true,
+            autoconnect_priority: 0,
+            timestamp_unix: 0,
+            permissions: Vec::new(),
+            unsaved: false,
+            filename: None,
+            summary: SettingsSummary::Wifi {
+                ssid: ssid.to_string(),
+                mode: Some("infrastructure".into()),
+                security: None,
+                band: None,
+                channel: None,
+                bssid: bssid.map(ToOwned::to_owned),
+                hidden: false,
+                mac_randomization: None,
+            },
+        }
+    }
+
+    fn saved_vpn(index: usize, uuid: &str) -> SavedConnection {
+        SavedConnection {
+            path: object_path(&format!("/org/freedesktop/NetworkManager/Settings/{index}")),
+            uuid: uuid.to_string(),
+            id: format!("VPN {index}"),
+            connection_type: "vpn".to_string(),
+            interface_name: None,
+            autoconnect: false,
+            autoconnect_priority: 0,
+            timestamp_unix: 0,
+            permissions: Vec::new(),
+            unsaved: false,
+            filename: None,
+            summary: SettingsSummary::Vpn {
+                service_type: "org.freedesktop.NetworkManager.openvpn".into(),
+                user_name: None,
+                password_flags: VpnSecretFlags(0),
+                data_keys: Vec::new(),
+                persistent: false,
+            },
+        }
+    }
+
+    fn saved_wireguard(index: usize, uuid: &str) -> SavedConnection {
+        SavedConnection {
+            path: object_path(&format!("/org/freedesktop/NetworkManager/Settings/{index}")),
+            uuid: uuid.to_string(),
+            id: format!("WireGuard {index}"),
+            connection_type: "wireguard".to_string(),
+            interface_name: None,
+            autoconnect: false,
+            autoconnect_priority: 0,
+            timestamp_unix: 0,
+            permissions: Vec::new(),
+            unsaved: false,
+            filename: None,
+            summary: SettingsSummary::WireGuard {
+                listen_port: None,
+                mtu: None,
+                fwmark: None,
+                peer_count: 1,
+                first_peer_endpoint: None,
+            },
+        }
+    }
+
+    fn active_wifi(interface: &str, ssid: &str, bssid: Option<&str>) -> ActiveConnection {
+        ActiveConnection::Wifi(ActiveWifiConnection {
+            id: ssid.to_string(),
+            uuid: format!("{ssid}-active"),
+            ssid: ssid.to_string(),
+            interface: Some(interface.to_string()),
+            bssid: bssid.map(ToOwned::to_owned),
+            strength: None,
+            ip4_address: None,
+            ip6_address: None,
+            state: ActiveConnectionState::Activated,
+        })
+    }
+
+    fn active_vpn(uuid: &str) -> ActiveConnection {
+        ActiveConnection::Vpn(ActiveVpnConnection {
+            id: "VPN".into(),
+            uuid: uuid.to_string(),
+            interface: None,
+            ip4_address: None,
+            ip6_address: None,
+            state: ActiveConnectionState::Activated,
+        })
+    }
+
     #[test]
     fn filters_saved_wifi_profiles() {
         let profiles = vec![
-            saved("802-11-wireless"),
+            saved_wifi(1, "wifi-uuid", "Cafe", None, None),
             saved("vpn"),
             saved("802-3-ethernet"),
         ];
@@ -106,5 +544,128 @@ mod tests {
             vpn.iter()
                 .any(|profile| profile.connection_type == "wireguard")
         );
+    }
+
+    #[test]
+    fn groups_duplicate_ssids_on_one_interface() {
+        let snapshot = snapshot(
+            vec![
+                ap("wlan0", "Cafe", "AA:AA:AA:AA:AA:01", 30),
+                ap("wlan0", "Cafe", "AA:AA:AA:AA:AA:02", 80),
+            ],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let groups = snapshot.wifi_groups();
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].ssid, "Cafe");
+        assert_eq!(groups[0].interface, "wlan0");
+        assert_eq!(groups[0].access_points.len(), 2);
+        assert_eq!(groups[0].strongest.bssid, "AA:AA:AA:AA:AA:02");
+    }
+
+    #[test]
+    fn keeps_same_ssid_on_two_interfaces_separate() {
+        let snapshot = snapshot(
+            vec![
+                ap("wlan0", "Cafe", "AA:AA:AA:AA:AA:01", 70),
+                ap("wlan1", "Cafe", "BB:BB:BB:BB:BB:01", 90),
+            ],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let groups = snapshot.wifi_groups();
+
+        assert_eq!(groups.len(), 2);
+        assert!(groups.iter().any(|group| group.interface == "wlan0"));
+        assert!(groups.iter().any(|group| group.interface == "wlan1"));
+    }
+
+    #[test]
+    fn matches_bssid_pinned_saved_profiles() {
+        let snapshot = snapshot(
+            vec![
+                ap("wlan0", "Cafe", "AA:AA:AA:AA:AA:01", 70),
+                ap("wlan0", "Cafe", "AA:AA:AA:AA:AA:02", 90),
+            ],
+            vec![
+                saved_wifi(10, "matches", "Cafe", None, Some("AA:AA:AA:AA:AA:02")),
+                saved_wifi(11, "misses", "Cafe", None, Some("CC:CC:CC:CC:CC:01")),
+            ],
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let groups = snapshot.wifi_groups();
+
+        assert!(groups[0].known);
+        assert_eq!(groups[0].saved_profiles.len(), 1);
+        assert_eq!(groups[0].saved_profiles[0].uuid, "matches");
+    }
+
+    #[test]
+    fn keeps_hidden_saved_profiles_without_visible_aps() {
+        let snapshot = snapshot(
+            Vec::new(),
+            vec![saved_wifi(10, "hidden", "Hidden", None, None)],
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let groups = snapshot.wifi_groups();
+        let known = snapshot.known_wifi_by_ssid();
+
+        assert!(groups.is_empty());
+        assert_eq!(known["Hidden"][0].uuid, "hidden");
+    }
+
+    #[test]
+    fn detects_active_wifi_group_and_prefers_active_bssid_on_tie() {
+        let snapshot = snapshot(
+            vec![
+                ap("wlan0", "Cafe", "AA:AA:AA:AA:AA:01", 70),
+                ap("wlan0", "Cafe", "AA:AA:AA:AA:AA:02", 70),
+                ap("wlan1", "Cafe", "BB:BB:BB:BB:BB:01", 90),
+            ],
+            Vec::new(),
+            Vec::new(),
+            vec![active_wifi("wlan0", "Cafe", Some("AA:AA:AA:AA:AA:02"))],
+        );
+
+        let groups = snapshot.wifi_groups();
+        let wlan0 = groups
+            .iter()
+            .find(|group| group.interface == "wlan0")
+            .expect("wlan0 group");
+        let wlan1 = groups
+            .iter()
+            .find(|group| group.interface == "wlan1")
+            .expect("wlan1 group");
+
+        assert!(wlan0.active);
+        assert!(!wlan1.active);
+        assert_eq!(wlan0.strongest.bssid, "AA:AA:AA:AA:AA:02");
+    }
+
+    #[test]
+    fn marks_saved_vpn_active_by_uuid() {
+        let snapshot = snapshot(
+            Vec::new(),
+            Vec::new(),
+            vec![saved_vpn(20, "active-vpn"), saved_wireguard(21, "wg-vpn")],
+            vec![active_vpn("active-vpn")],
+        );
+
+        let vpns = snapshot.saved_vpn_map();
+
+        assert!(vpns["active-vpn"].active);
+        assert!(!vpns["wg-vpn"].active);
+        assert_eq!(vpns["active-vpn"].kind, Some(VpnKind::Plugin));
+        assert_eq!(vpns["wg-vpn"].kind, Some(VpnKind::WireGuard));
     }
 }

--- a/nmrs/src/api/models/vpn.rs
+++ b/nmrs/src/api/models/vpn.rs
@@ -27,6 +27,20 @@ pub enum VpnKind {
     WireGuard,
 }
 
+/// Saved VPN profile summary for applet lists.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct SavedVpnSummary {
+    /// Connection UUID.
+    pub uuid: String,
+    /// Human-visible connection id.
+    pub id: String,
+    /// VPN implementation kind, when it can be inferred from saved settings.
+    pub kind: Option<VpnKind>,
+    /// `true` when an active VPN connection has the same UUID.
+    pub active: bool,
+}
+
 /// OpenVPN authentication/connection type.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]

--- a/nmrs/src/api/models/wifi.rs
+++ b/nmrs/src/api/models/wifi.rs
@@ -1,7 +1,31 @@
 use serde::{Deserialize, Serialize};
 
-use super::access_point::SecurityFeatures;
+use super::access_point::{AccessPoint, SecurityFeatures};
 use super::error::ConnectionError;
+use super::saved_connection::SavedConnectionBrief;
+
+/// Visible Wi-Fi access points grouped by interface and SSID for applet UIs.
+///
+/// A group preserves every BSSID seen for one `(interface, ssid)` pair while
+/// exposing the strongest AP as the representative row.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct WifiNetworkGroup {
+    /// SSID shared by every access point in this group.
+    pub ssid: String,
+    /// Wi-Fi interface that sees this group.
+    pub interface: String,
+    /// Strongest AP in the group, preferring the active BSSID on ties.
+    pub strongest: AccessPoint,
+    /// All APs in the group, sorted strongest first.
+    pub access_points: Vec<AccessPoint>,
+    /// Saved Wi-Fi profiles that match this visible group.
+    pub saved_profiles: Vec<SavedConnectionBrief>,
+    /// `true` when a typed active Wi-Fi connection matches this group.
+    pub active: bool,
+    /// `true` when at least one saved profile matches this visible group.
+    pub known: bool,
+}
 
 /// Represents a Wi-Fi network discovered during a scan.
 ///

--- a/nmrs/src/lib.rs
+++ b/nmrs/src/lib.rs
@@ -414,16 +414,17 @@ pub mod models {
 pub use api::models::{
     AccessPoint, ActiveConnection, ActiveConnectionState, ActiveOtherConnection,
     ActiveVpnConnection, ActiveWifiConnection, ActiveWiredConnection, AirplaneModeState, ApMode,
-    BluetoothDevice, BluetoothIdentity, BluetoothNetworkRole, ConnectType, ConnectionError,
-    ConnectionOptions, ConnectionStateReason, ConnectivityReport, ConnectivityState, Device,
-    DeviceState, DeviceType, EapMethod, EapOptions, Network, NetworkEvent, NetworkEventStream,
-    NetworkInfo, NetworkSnapshot, OpenVpnAuthType, OpenVpnCompression, OpenVpnConfig,
-    OpenVpnConnectionType, OpenVpnProxy, Phase2, RadioState, SavedConnection, SavedConnectionBrief,
-    SecurityFeatures, SettingsChange, SettingsEventStream, SettingsPatch, SettingsSummary,
-    StateReason, TimeoutConfig, VlanConfig, VpnConfig, VpnConfiguration, VpnConnection,
-    VpnConnectionInfo, VpnCredentials, VpnDetails, VpnKind, VpnRoute, VpnSecretFlags, VpnType,
-    WifiDevice, WifiKeyMgmt, WifiSecurity, WifiSecuritySummary, WireGuardConfig, WireGuardPeer,
-    WiredDevice, connection_state_reason_to_error, reason_to_error,
+    AppletNetworkSummary, BluetoothDevice, BluetoothIdentity, BluetoothNetworkRole, ConnectType,
+    ConnectionError, ConnectionOptions, ConnectionStateReason, ConnectivityReport,
+    ConnectivityState, Device, DeviceState, DeviceType, EapMethod, EapOptions, Network,
+    NetworkEvent, NetworkEventStream, NetworkInfo, NetworkSnapshot, OpenVpnAuthType,
+    OpenVpnCompression, OpenVpnConfig, OpenVpnConnectionType, OpenVpnProxy, Phase2, RadioState,
+    SavedConnection, SavedConnectionBrief, SavedVpnSummary, SecurityFeatures, SettingsChange,
+    SettingsEventStream, SettingsPatch, SettingsSummary, StateReason, TimeoutConfig, VlanConfig,
+    VpnConfig, VpnConfiguration, VpnConnection, VpnConnectionInfo, VpnCredentials, VpnDetails,
+    VpnKind, VpnRoute, VpnSecretFlags, VpnType, WifiDevice, WifiKeyMgmt, WifiNetworkGroup,
+    WifiSecurity, WifiSecuritySummary, WireGuardConfig, WireGuardPeer, WiredDevice,
+    connection_state_reason_to_error, reason_to_error,
 };
 pub use api::network_manager::NetworkManager;
 pub use api::wifi_scope::WifiScope;


### PR DESCRIPTION
Adds applet-oriented snapshot helpers for grouping visible Wi-Fi APs by interface and SSID, matching saved Wi-Fi profiles, and summarizing saved VPN state.

These helpers let the applet derive Wi-Fi rows, known networks, active Wi-Fi state, and saved VPN activity directly from `NetworkSnapshot` without extra D-Bus reads.