### PR TITLE
feat: expose existing secrets on SecretRequest for re-auth prefill

### DIFF
--- a/nmrs/src/agent/iface.rs
+++ b/nmrs/src/agent/iface.rs
@@ -17,7 +17,7 @@ use crate::types::constants::timeouts;
 
 use super::request::{
     CancelReason, ConnectionDict, SecretAgentFlags, SecretReply, SecretRequest, SecretResponder,
-    SecretStoreEvent, extract_setting_string, parse_secret_setting,
+    SecretStoreEvent, extract_existing_secrets, extract_setting_string, parse_secret_setting,
 };
 
 /// Custom D-Bus error type for the SecretAgent interface.
@@ -89,6 +89,7 @@ impl SecretAgentInterface {
             hints,
             flags: SecretAgentFlags::from_bits_truncate(flags),
             responder: SecretResponder::new(reply_tx, setting_name.to_owned()),
+            existing_secrets: extract_existing_secrets(&connection, setting_name),
         };
 
         // Send to the consumer stream. If the channel is full or closed,

--- a/nmrs/src/agent/request.rs
+++ b/nmrs/src/agent/request.rs
@@ -127,6 +127,10 @@ pub struct SecretRequest {
     pub flags: SecretAgentFlags,
     /// The responder used to reply with secrets or cancel.
     pub responder: SecretResponder,
+    /// Existing secrets NetworkManager sent in the `GetSecrets` payload, for
+    /// pre-filling a re-authentication prompt. Currently only populated for
+    /// `vpn` connections, and only for system-owned secrets.
+    pub existing_secrets: HashMap<String, String>,
 }
 
 impl std::fmt::Debug for SecretRequest {
@@ -381,6 +385,32 @@ pub(crate) fn parse_secret_setting(
     }
 }
 
+/// Extracts the secrets already present in the `GetSecrets` payload.
+///
+/// Only `vpn` connections are handled, mirroring
+/// [`SecretResponder::vpn_secrets`] by reading the map nested under
+/// `vpn.secrets`. Other settings return an empty map.
+pub(crate) fn extract_existing_secrets(
+    connection: &ConnectionDict,
+    setting_name: &str,
+) -> HashMap<String, String> {
+    let Some(section) = connection.get(setting_name) else {
+        return HashMap::new();
+    };
+
+    if setting_name == "vpn" {
+        return section
+            .get("secrets")
+            .and_then(|v| <HashMap<String, String>>::try_from(v.clone()).ok())
+            .unwrap_or_default();
+    }
+
+    // Other connection types would require reading their individual secret
+    // keys ("psk", "wep-key0", "password", etc.); not currently handled.
+
+    HashMap::new()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -418,6 +448,56 @@ mod tests {
         let connection = HashMap::new();
         let setting = parse_secret_setting(&connection, "some-custom-thing");
         assert!(matches!(setting, SecretSetting::Other(s) if s == "some-custom-thing"));
+    }
+
+    #[test]
+    fn extract_existing_secrets_reads_vpn_secrets() {
+        let mut secrets = HashMap::new();
+        secrets.insert("password".to_owned(), "hunter2".to_owned());
+        secrets.insert("Xauth password".to_owned(), "otp".to_owned());
+
+        let mut vpn = HashMap::new();
+        vpn.insert("secrets".to_owned(), OwnedValue::from(secrets));
+        let mut connection = ConnectionDict::new();
+        connection.insert("vpn".to_owned(), vpn);
+
+        let existing = extract_existing_secrets(&connection, "vpn");
+        assert_eq!(
+            existing.get("password").map(String::as_str),
+            Some("hunter2")
+        );
+        assert_eq!(
+            existing.get("Xauth password").map(String::as_str),
+            Some("otp")
+        );
+    }
+
+    #[test]
+    fn extract_existing_secrets_vpn_without_secrets_is_empty() {
+        // A `vpn` section present but with no nested `secrets` sub-dict.
+        let mut connection = ConnectionDict::new();
+        connection.insert("vpn".to_owned(), HashMap::new());
+        assert!(extract_existing_secrets(&connection, "vpn").is_empty());
+    }
+
+    #[test]
+    fn extract_existing_secrets_missing_section_is_empty() {
+        let connection = ConnectionDict::new();
+        assert!(extract_existing_secrets(&connection, "vpn").is_empty());
+    }
+
+    #[test]
+    fn extract_existing_secrets_non_vpn_is_empty() {
+        // Non-VPN settings are intentionally not populated (see fn docs).
+        let mut inner = HashMap::new();
+        inner.insert(
+            "psk".to_owned(),
+            OwnedValue::from(Str::from("should-be-ignored")),
+        );
+        let mut connection = ConnectionDict::new();
+        connection.insert("802-11-wireless-security".to_owned(), inner);
+
+        assert!(extract_existing_secrets(&connection, "802-11-wireless-security").is_empty());
     }
 
     #[test]


### PR DESCRIPTION
I had initially planned to add more connection types , but it turns out that unlike "vpn" which maps quite cleanly under "secrets", other protocols use a variety of names, `psk`, `wep-key*`, `password`, etc. As far as I can tell, these can only be sourced by traversing the Network Manager source code. This felt out of scope, and also quite error prone.
I'm happy to add some more as a best effort kind of thing if that is preferred.

Other than that, I have tested this with a custom build of the Cosmic Network Applet, and the existing password is retrieved correctly for my VPN connection. 

Closes #456