### PR TITLE
feat(#462): expose dbus connection and raw zbus re-exports

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -53,6 +53,7 @@
 - [NetworkManager](./api/network-manager.md)
 - [Models Module](./api/models.md)
 - [Builders Module](./api/builders.md)
+- [Raw Module](./api/raw.md)
 - [Error Types](./api/errors.md)
 
 # Development

--- a/docs/src/advanced/connection-options.md
+++ b/docs/src/advanced/connection-options.md
@@ -86,10 +86,11 @@ let settings = ConnectionBuilder::new("802-11-wireless", "MyNetwork")
     .build();
 ```
 
-The high-level `NetworkManager` API uses `ConnectionOptions::default()` internally. For custom options, use the builder APIs directly.
+The high-level `NetworkManager` API uses `ConnectionOptions::default()` internally. For custom options, build a settings dictionary with the builder APIs and submit it via [`dbus_connection()`](../api/network-manager.md#advanced-d-bus-access). See [Submitting Builder Output](../api/builders.md#submitting-builder-output).
 
 ## Next Steps
 
 - [Custom Timeouts](./timeouts.md) – control how long operations wait
 - [Builders Module](../api/builders.md) – low-level connection building
+- [Raw Module](../api/raw.md) – `zbus` / `zvariant` re-exports
 - [D-Bus Architecture](./dbus.md) – how settings are sent to NetworkManager

--- a/docs/src/advanced/dbus.md
+++ b/docs/src/advanced/dbus.md
@@ -36,6 +36,18 @@ let nm = NetworkManager::new().await?;
 
 This creates a persistent D-Bus connection that's shared across all operations.
 
+### Advanced access
+
+For builder workflows and other low-level D-Bus calls, nmrs exposes the same
+connection through [`NetworkManager::dbus_connection()`](../api/network-manager.md#advanced-d-bus-access).
+Pair it with [`nmrs::raw`](../api/raw.md) (`zbus` / `zvariant` re-exports) so
+the types returned by builders are compatible with the connection nmrs manages.
+
+Most applications should keep using the high-level `NetworkManager` methods.
+Reach for `dbus_connection()` only when you need to call NetworkManager D-Bus
+methods that nmrs does not wrap yet (for example `AddAndActivateConnection`
+with custom builder output).
+
 ### Method Calls
 
 API methods like `list_devices()` translate to D-Bus method calls:
@@ -76,7 +88,7 @@ nmrs: nm.connect("MyWiFi", None, WifiSecurity::WpaPsk { psk: "..." })
 
 ## D-Bus Proxy Types
 
-nmrs wraps D-Bus interfaces in typed proxy structs (defined in `nmrs::dbus`):
+nmrs wraps D-Bus interfaces in typed proxy structs (defined in the internal `dbus` module):
 
 | Proxy | D-Bus Interface | Purpose |
 |-------|----------------|---------|
@@ -88,7 +100,13 @@ nmrs wraps D-Bus interfaces in typed proxy structs (defined in `nmrs::dbus`):
 | `NMWiredProxy` | `org.freedesktop.NetworkManager.Device.Wired` | Wired device properties |
 | `NMBluetoothProxy` | `org.freedesktop.NetworkManager.Device.Bluetooth` | Bluetooth properties |
 
-These are internal types — you interact with them through the high-level `NetworkManager` API.
+These proxy types are **not** part of the public API. Normal callers interact
+with NetworkManager through the high-level [`NetworkManager`](../api/network-manager.md)
+methods.
+
+Advanced callers can define their own minimal `#[zbus::proxy]` traits on top of
+[`dbus_connection()`](../api/network-manager.md#advanced-d-bus-access) and
+[`nmrs::raw`](../api/raw.md). See [Submitting Builder Output](../api/builders.md#submitting-builder-output).
 
 ## D-Bus Errors
 
@@ -143,5 +161,7 @@ busctl list | grep NetworkManager
 
 ## Next Steps
 
+- [Raw Module](../api/raw.md) – `zbus` / `zvariant` re-exports for advanced callers
+- [Builders Module](../api/builders.md) – construct and submit custom settings dictionaries
 - [Logging and Debugging](./logging.md) – enable nmrs debug logging
 - [Architecture](../development/architecture.md) – internal code structure

--- a/docs/src/api/builders.md
+++ b/docs/src/api/builders.md
@@ -1,6 +1,8 @@
 # Builders Module
 
-The `builders` module provides low-level APIs for constructing NetworkManager connection settings. Most users should use the high-level `NetworkManager` API instead — these builders are for advanced use cases where you need fine-grained control.
+The `builders` module provides low-level APIs for constructing NetworkManager connection settings. Most users should use the high-level `NetworkManager` API instead — these builders are for advanced use cases where you need fine-grained control over the settings dictionary before calling NetworkManager D-Bus methods directly.
+
+To submit builder output, use [`NetworkManager::dbus_connection()`](./network-manager.md#advanced-d-bus-access) together with [`nmrs::raw`](./raw.md) (`zbus` / `zvariant` re-exports). See [Submitting Builder Output](#submitting-builder-output) below.
 
 ## ConnectionBuilder
 
@@ -148,6 +150,68 @@ Use the builders when you need:
 
 For standard connections, the `NetworkManager` API handles everything automatically.
 
+## Submitting Builder Output
+
+Builders produce a NetworkManager settings dictionary
+(`HashMap<&str, HashMap<&str, zvariant::Value>>`). To activate that profile you
+need the same system D-Bus connection nmrs already manages, plus compatible
+`zbus` / `zvariant` types from [`nmrs::raw`](./raw.md).
+
+### Wi-Fi hotspot (AP mode)
+
+This is the workflow for cases such as [#260](https://github.com/freedesktop-rs/nmrs/issues/260) where the high-level `connect()` API does not expose every builder knob (for example `WifiMode::Ap`):
+
+```rust
+use nmrs::builders::{WifiConnectionBuilder, WifiMode};
+use nmrs::raw::{zbus, zvariant};
+use nmrs::{NetworkManager, Result};
+
+#[zbus::proxy(
+    interface = "org.freedesktop.NetworkManager",
+    default_service = "org.freedesktop.NetworkManager",
+    default_path = "/org/freedesktop/NetworkManager"
+)]
+trait Nm {
+    fn add_and_activate_connection(
+        &self,
+        connection: std::collections::HashMap<
+            &str,
+            std::collections::HashMap<&str, zvariant::Value<'_>>,
+        >,
+        device: zvariant::OwnedObjectPath,
+        specific_object: zvariant::OwnedObjectPath,
+    ) -> zbus::Result<(zvariant::OwnedObjectPath, zvariant::OwnedObjectPath)>;
+}
+
+async fn start_hotspot(nm: &NetworkManager, interface: &str) -> Result<()> {
+    let settings = WifiConnectionBuilder::new("Hotspot")
+        .wpa_psk("password")
+        .mode(WifiMode::Ap)
+        .ipv4_shared()
+        .ipv6_ignore()
+        .build();
+
+    let device = nm.get_device_by_interface(interface).await?;
+    let proxy = NmProxy::new(nm.dbus_connection()).await?;
+    proxy
+        .add_and_activate_connection(settings, device, "/".into())
+        .await?;
+
+    Ok(())
+}
+```
+
+Notes:
+
+- Use `"/"` as `specific_object` for AP mode and other cases where there is no target access point.
+- For client (infrastructure) mode, resolve an access-point object path first (nmrs does this internally in `connect()`).
+- Map D-Bus errors to `ConnectionError::Dbus` (or handle them in your own error type).
+- nmrs does not yet provide a high-level wrapper for `AddConnection` / `AddAndActivateConnection`; `dbus_connection()` is the supported escape hatch.
+
+### Saving without activating
+
+To persist a profile without bringing it up immediately, define a proxy method for `AddConnection` instead and pass the same `settings` map. nmrs uses that D-Bus call internally when saving VPN profiles.
+
 ## OpenVpnBuilder
 
 Builds OpenVPN connection settings from an `OpenVpnConfig` or by importing a `.ovpn` file.
@@ -187,3 +251,9 @@ nm.import_ovpn("client.ovpn", Some("user"), Some("secret")).await?;
 ## Full API Reference
 
 See [docs.rs/nmrs](https://docs.rs/nmrs) for complete builder documentation.
+
+## See Also
+
+- [Raw Module](./raw.md) – `zbus` / `zvariant` re-exports for advanced D-Bus work
+- [NetworkManager API](./network-manager.md#advanced-d-bus-access) – `dbus_connection()`
+- [D-Bus Architecture](../advanced/dbus.md) – how settings reach NetworkManager

--- a/docs/src/api/network-manager.md
+++ b/docs/src/api/network-manager.md
@@ -21,6 +21,22 @@ let nm = NetworkManager::with_config(config).await?;
 let config = nm.timeout_config();
 ```
 
+## Advanced D-Bus Access
+
+```rust
+use nmrs::raw::{zbus, zvariant};
+
+let conn = nm.dbus_connection(); // &zbus::Connection
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `dbus_connection()` | `&zbus::Connection` | Shared system bus connection for advanced D-Bus calls |
+
+Use this with [`nmrs::raw`](./raw.md) and the [builders](./builders.md) module
+when you need to call NetworkManager methods such as `AddConnection` or
+`AddAndActivateConnection` directly. See [Submitting Builder Output](./builders.md#submitting-builder-output).
+
 ## Wi-Fi Methods
 
 | Method | Returns | Description |
@@ -134,8 +150,10 @@ let config = nm.timeout_config();
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `monitor_network_changes(callback)` | `Result<()>` | Watch for AP and signal strength changes (runs forever) |
-| `monitor_device_changes(callback)` | `Result<()>` | Watch for device state changes (runs forever) |
+| `monitor_network_changes(callback)` | `Result<MonitorHandle>` | Watch for AP and signal strength changes |
+| `monitor_device_changes(callback)` | `Result<MonitorHandle>` | Watch for device state changes |
+
+Call `MonitorHandle::stop().await?` to shut down a monitor cleanly.
 
 ## Thread Safety
 

--- a/docs/src/api/raw.md
+++ b/docs/src/api/raw.md
@@ -1,0 +1,44 @@
+# Raw Module
+
+The `nmrs::raw` module re-exports the D-Bus dependencies nmrs uses internally:
+
+```rust
+pub mod raw {
+    pub use zbus;
+    pub use zvariant;
+}
+```
+
+Use it together with [`NetworkManager::dbus_connection()`](./network-manager.md#advanced-d-bus-access) when you need to call NetworkManager D-Bus methods directly — for example after building a settings dictionary with the [`builders`](./builders.md) module.
+
+## Why it exists
+
+Builder methods such as `WifiConnectionBuilder::build()` return
+`HashMap<&str, HashMap<&str, zvariant::Value<'_>>>`. Without `nmrs::raw`,
+consumers would need to depend on their own `zbus` / `zvariant` versions and
+hope they match the ones nmrs was built against.
+
+Re-exporting them under `nmrs::raw` keeps those types compatible with builder
+output and with the connection returned by `dbus_connection()`.
+
+## Typical workflow
+
+1. Build settings with a builder (for example `WifiConnectionBuilder`).
+2. Obtain the shared system bus connection via `nm.dbus_connection()`.
+3. Create a zbus proxy on that connection using `nmrs::raw::zbus`.
+4. Call `AddConnection` or `AddAndActivateConnection` on NetworkManager.
+
+See [Submitting Builder Output](./builders.md#submitting-builder-output) for a
+full Wi-Fi hotspot example and [D-Bus Architecture](../advanced/dbus.md) for
+background on how nmrs talks to NetworkManager.
+
+## What is not exposed
+
+`nmrs::raw` does **not** re-export nmrs's internal D-Bus proxy types from
+`nmrs::dbus`. Those remain implementation details. Advanced callers define
+their own minimal `#[zbus::proxy]` traits (or use `call_method` directly) on
+top of `dbus_connection()` and `nmrs::raw`.
+
+## Full API Reference
+
+See [docs.rs/nmrs::raw](https://docs.rs/nmrs/latest/nmrs/raw/index.html).

--- a/docs/src/api/types.md
+++ b/docs/src/api/types.md
@@ -16,6 +16,7 @@ let nm = NetworkManager::with_config(config).await?;
 - `Clone` — clones share the same D-Bus connection
 - `Send + Sync` — safe to share across tasks
 - See [NetworkManager API](./network-manager.md) for all methods
+- See [Raw Module](./raw.md) for `zbus` / `zvariant` re-exports used with `dbus_connection()`
 
 ## Result Type
 
@@ -110,6 +111,16 @@ All public methods return `nmrs::Result<T>`.
 |------|-------------|
 | `TimeoutConfig` | Connection/disconnection timeouts |
 | `ConnectionOptions` | Autoconnect, priority, retry settings |
+| `MonitorHandle` | Handle returned by monitor APIs; call `stop().await?` to shut down |
+
+## Raw Module
+
+| Module | Description |
+|--------|-------------|
+| `nmrs::raw::zbus` | Re-exported zbus dependency for advanced D-Bus work |
+| `nmrs::raw::zvariant` | Re-exported zvariant dependency (builder output types) |
+
+See [Raw Module](./raw.md) and [`dbus_connection()`](./network-manager.md#advanced-d-bus-access).
 
 ## Error Types
 
@@ -156,4 +167,5 @@ Less commonly used types are available through the `models` and `builders` modul
 ```rust
 use nmrs::models::{BluetoothIdentity, BluetoothNetworkRole, BluetoothDevice};
 use nmrs::builders::{ConnectionBuilder, WireGuardBuilder, OpenVpnBuilder, IpConfig, Route};
+use nmrs::raw::{zbus, zvariant};
 ```

--- a/docs/src/development/architecture.md
+++ b/docs/src/development/architecture.md
@@ -6,7 +6,7 @@ This page describes the internal architecture of the nmrs library. Understanding
 
 ```
 nmrs/src/
-├── lib.rs              # Crate root: re-exports, Result type alias
+├── lib.rs              # Crate root: re-exports, Result type alias, raw module
 ├── api/                # Public API layer
 │   ├── mod.rs
 │   ├── network_manager.rs   # NetworkManager struct and methods
@@ -73,11 +73,12 @@ nmrs/src/
 │  api/network_manager.rs  ← Public API (NetworkManager)   │
 │  api/models/             ← Public data types              │
 │  api/builders/           ← Public connection builders     │
+│  lib.rs::raw             ← zbus / zvariant re-exports     │
 ├──────────────────────────────────────────────────────────┤
 │  core/                   ← Business logic (not public)    │
 │  monitoring/             ← Signal monitoring (not public) │
 ├──────────────────────────────────────────────────────────┤
-│  dbus/                   ← D-Bus proxy types (not public) │
+│  dbus/                   ← Internal D-Bus proxy types       │
 │  util/                   ← Utilities (not public)         │
 │  types/                  ← Constants (not public)         │
 ├──────────────────────────────────────────────────────────┤
@@ -93,6 +94,8 @@ The `api` module defines the public interface:
 - `NetworkManager` delegates to `core` functions
 - `models` define all public data types
 - `builders` construct NM settings dictionaries
+- `raw` re-exports `zbus` and `zvariant` for advanced D-Bus callers
+- `NetworkManager::dbus_connection()` exposes the shared system bus connection
 
 ### Core Layer
 

--- a/docs/src/guide/monitoring.md
+++ b/docs/src/guide/monitoring.md
@@ -2,6 +2,9 @@
 
 nmrs uses D-Bus signals to provide real-time notifications when network state changes. This is more efficient than polling — your callback fires only when something actually changes.
 
+Both `monitor_network_changes()` and `monitor_device_changes()` return a
+[`MonitorHandle`](../api/types.md) you can use to shut the monitor down cleanly.
+
 ## Network Change Monitoring
 
 Subscribe to network changes (access points appearing or disappearing, or signal
@@ -14,11 +17,13 @@ use nmrs::NetworkManager;
 async fn main() -> nmrs::Result<()> {
     let nm = NetworkManager::new().await?;
 
-    // This runs indefinitely — spawn it as a background task
-    nm.monitor_network_changes(|| {
+    let handle = nm.monitor_network_changes(|| {
         println!("Network list changed!");
     }).await?;
 
+    // ... application work ...
+
+    handle.stop().await?;
     Ok(())
 }
 ```
@@ -36,10 +41,13 @@ use nmrs::NetworkManager;
 async fn main() -> nmrs::Result<()> {
     let nm = NetworkManager::new().await?;
 
-    nm.monitor_device_changes(|| {
+    let handle = nm.monitor_device_changes(|| {
         println!("Device state changed!");
     }).await?;
 
+    // ... application work ...
+
+    handle.stop().await?;
     Ok(())
 }
 ```
@@ -48,7 +56,8 @@ async fn main() -> nmrs::Result<()> {
 
 ## Running Monitors as Background Tasks
 
-Both monitoring functions run indefinitely. In a real application, spawn them as background tasks:
+In a real application, spawn monitors as background tasks and keep the returned
+`MonitorHandle` so you can stop them on shutdown:
 
 ### With Tokio
 
@@ -59,30 +68,32 @@ use nmrs::NetworkManager;
 async fn main() -> nmrs::Result<()> {
     let nm = NetworkManager::new().await?;
 
-    // Spawn network monitor
-    let nm_clone = nm.clone();
-    tokio::spawn(async move {
-        if let Err(e) = nm_clone.monitor_network_changes(|| {
-            println!("Networks changed");
-        }).await {
-            eprintln!("Network monitor error: {}", e);
-        }
-    });
+    let net_handle = {
+        let nm = nm.clone();
+        tokio::spawn(async move {
+            nm.monitor_network_changes(|| {
+                println!("Networks changed");
+            }).await
+        })
+    };
 
-    // Spawn device monitor
-    let nm_clone = nm.clone();
-    tokio::spawn(async move {
-        if let Err(e) = nm_clone.monitor_device_changes(|| {
-            println!("Device state changed");
-        }).await {
-            eprintln!("Device monitor error: {}", e);
-        }
-    });
+    let dev_handle = {
+        let nm = nm.clone();
+        tokio::spawn(async move {
+            nm.monitor_device_changes(|| {
+                println!("Device state changed");
+            }).await
+        })
+    };
 
     // Your main application logic here
     loop {
         tokio::time::sleep(std::time::Duration::from_secs(60)).await;
     }
+
+    // On shutdown:
+    // net_handle.await??.stop().await?;
+    // dev_handle.await??.stop().await?;
 }
 ```
 
@@ -94,23 +105,22 @@ use nmrs::NetworkManager;
 // Inside a GTK application
 let nm = NetworkManager::new().await?;
 
-glib::MainContext::default().spawn_local({
+let net_handle = glib::MainContext::default().spawn_local({
     let nm = nm.clone();
-    async move {
-        let _ = nm.monitor_network_changes(|| {
-            println!("Networks changed — refresh the UI!");
-        }).await;
-    }
+    async move { nm.monitor_network_changes(|| {
+        println!("Networks changed — refresh the UI!");
+    }).await }
 });
 
-glib::MainContext::default().spawn_local({
+let dev_handle = glib::MainContext::default().spawn_local({
     let nm = nm.clone();
-    async move {
-        let _ = nm.monitor_device_changes(|| {
-            println!("Device changed — update status!");
-        }).await;
-    }
+    async move { nm.monitor_device_changes(|| {
+        println!("Device changed — update status!");
+    }).await }
 });
+
+// Keep `net_handle` / `dev_handle` alive, then call `MonitorHandle::stop()`
+// when tearing down the UI.
 ```
 
 ## Thread Safety
@@ -131,22 +141,24 @@ async fn main() -> nmrs::Result<()> {
     let nm = NetworkManager::new().await?;
     let notify = Arc::new(Notify::new());
 
-    // Monitor for changes
-    let notify_clone = notify.clone();
-    let nm_clone = nm.clone();
-    tokio::spawn(async move {
-        let _ = nm_clone.monitor_network_changes(move || {
-            notify_clone.notify_one();
-        }).await;
-    });
+    let handle = {
+        let notify = notify.clone();
+        let nm = nm.clone();
+        tokio::spawn(async move {
+            nm.monitor_network_changes(move || {
+                notify.notify_one();
+            }).await
+        })
+    };
 
-    // React to changes
     loop {
         notify.notified().await;
 
         let networks = nm.list_networks(None).await?;
         println!("Updated: {} networks visible", networks.len());
     }
+
+    // handle.await??.stop().await?;
 }
 ```
 

--- a/docs/src/guide/wifi.md
+++ b/docs/src/guide/wifi.md
@@ -155,10 +155,10 @@ let opts = ConnectionOptions::new(true)   // autoconnect
 
 This struct intentionally only covers the connection-management knobs
 NetworkManager exposes per-profile. To configure DHCP method, manual IP
-addresses, custom DNS servers, or static routes you need a builder — see
-the [`ConnectionBuilder`](../api/builders.md#connectionbuilder) reference,
-or use [`WifiConnectionBuilder`](../api/builders.md#wificonnectionbuilder)
-for Wi-Fi-specific defaults.
+addresses, custom DNS servers, static routes, or Wi-Fi modes such as AP/hotspot,
+use a builder — see the [`ConnectionBuilder`](../api/builders.md#connectionbuilder)
+reference, [`WifiConnectionBuilder`](../api/builders.md#wificonnectionbuilder),
+and [Submitting Builder Output](../api/builders.md#submitting-builder-output).
 
 ## WiFi Radio Control
 

--- a/nmrs/CHANGELOG.md
+++ b/nmrs/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the `nmrs` crate will be documented in this file.
 ### Added 
 - Expose existing secrets on SecretRequest for re-auth prefill ([#460](https://github.com/freedesktop-rs/nmrs/pull/460))
 - `MonitorHandle` returned by `monitor_network_changes` and `monitor_device_changes` for graceful shutdown ([#461](https://github.com/freedesktop-rs/nmrs/pull/461))
+- `NetworkManager::dbus_connection()` and `nmrs::raw` (`zbus` / `zvariant` re-exports) for advanced builder workflows ([#462](https://github.com/freedesktop-rs/nmrs/pull/464))
 
 ### Fixed
 - `monitor_network_changes` now detects hotplugged Wi-Fi devices instead of only monitoring devices present at startup ([#461](https://github.com/freedesktop-rs/nmrs/pull/461))

--- a/nmrs/CHANGELOG.md
+++ b/nmrs/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the `nmrs` crate will be documented in this file.
 - Expose existing secrets on SecretRequest for re-auth prefill ([#460](https://github.com/freedesktop-rs/nmrs/pull/460))
 - `MonitorHandle` returned by `monitor_network_changes` and `monitor_device_changes` for graceful shutdown ([#461](https://github.com/freedesktop-rs/nmrs/pull/461))
 - `NetworkManager::dbus_connection()` and `nmrs::raw` (`zbus` / `zvariant` re-exports) for advanced builder workflows ([#462](https://github.com/freedesktop-rs/nmrs/pull/464))
+- mdbook docs for `dbus_connection()`, `nmrs::raw`, and submitting builder output ([#462](https://github.com/freedesktop-rs/nmrs/pull/464))
 
 ### Fixed
 - `monitor_network_changes` now detects hotplugged Wi-Fi devices instead of only monitoring devices present at startup ([#461](https://github.com/freedesktop-rs/nmrs/pull/461))

--- a/nmrs/src/api/builders/mod.rs
+++ b/nmrs/src/api/builders/mod.rs
@@ -34,7 +34,9 @@
 //! builders directly. They are exposed for advanced use cases where you
 //! need fine-grained control over the raw settings dictionary before
 //! handing it to NetworkManager's `AddConnection` or
-//! `AddAndActivateConnection` D-Bus methods.
+//! `AddAndActivateConnection` D-Bus methods via
+//! [`NetworkManager::dbus_connection`](crate::NetworkManager::dbus_connection)
+//! and [`raw`](crate::raw).
 //!
 //! # Examples
 //!
@@ -52,6 +54,27 @@
 //!     &opts,
 //! );
 //! let eth = build_ethernet_connection("eth0", &opts);
+//! ```
+//!
+//! ## Wi-Fi hotspot (fluent builder + D-Bus)
+//!
+//! ```no_run
+//! use nmrs::builders::{WifiConnectionBuilder, WifiMode};
+//! use nmrs::NetworkManager;
+//!
+//! # async fn example() -> nmrs::Result<()> {
+//! let nm = NetworkManager::new().await?;
+//! let settings = WifiConnectionBuilder::new("Hotspot")
+//!     .wpa_psk("password")
+//!     .mode(WifiMode::Ap)
+//!     .ipv4_shared()
+//!     .build();
+//!
+//! let _conn = nm.dbus_connection();
+//! // Use `settings` with NetworkManager's AddAndActivateConnection on `_conn`
+//! // via `nmrs::raw::zbus` proxies.
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## WireGuard (fluent builder)
@@ -76,7 +99,8 @@
 //! ```
 //!
 //! The returned settings can then be passed to NetworkManager's
-//! `AddConnection` or `AddAndActivateConnection` D-Bus methods.
+//! `AddConnection` or `AddAndActivateConnection` D-Bus methods through
+//! [`NetworkManager::dbus_connection`](crate::NetworkManager::dbus_connection).
 
 pub mod bluetooth;
 pub mod connection_builder;

--- a/nmrs/src/api/network_manager.rs
+++ b/nmrs/src/api/network_manager.rs
@@ -234,6 +234,37 @@ impl NetworkManager {
         self.timeout_config
     }
 
+    /// Returns the underlying system D-Bus connection.
+    ///
+    /// Advanced callers can use this together with [`builders`](crate::builders)
+    /// and [`raw`](crate::raw) to invoke NetworkManager D-Bus methods such as
+    /// `AddConnection` or `AddAndActivateConnection` on the same connection
+    /// managed by this [`NetworkManager`] instance.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use nmrs::builders::{WifiConnectionBuilder, WifiMode};
+    /// use nmrs::NetworkManager;
+    ///
+    /// # async fn example() -> nmrs::Result<()> {
+    /// let nm = NetworkManager::new().await?;
+    /// let settings = WifiConnectionBuilder::new("Hotspot")
+    ///     .wpa_psk("password")
+    ///     .mode(WifiMode::Ap)
+    ///     .ipv4_shared()
+    ///     .build();
+    ///
+    /// let _conn = nm.dbus_connection();
+    /// // Pass `settings` to NetworkManager's AddAndActivateConnection via
+    /// // `nmrs::raw::zbus` proxies on `_conn`.
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn dbus_connection(&self) -> &Connection {
+        &self.conn
+    }
+
     /// List all network devices managed by NetworkManager.
     pub async fn list_devices(&self) -> Result<Vec<Device>> {
         list_devices(&self.conn).await

--- a/nmrs/src/lib.rs
+++ b/nmrs/src/lib.rs
@@ -310,6 +310,16 @@ mod util;
 /// lifecycle, and a full example.
 pub mod agent;
 
+/// Low-level D-Bus dependencies used by [`builders`](crate::builders).
+///
+/// Re-exports [`zbus`] and [`zvariant`] so advanced callers can construct
+/// proxies against [`NetworkManager::dbus_connection`](crate::NetworkManager::dbus_connection)
+/// without pinning their own potentially incompatible versions.
+pub mod raw {
+    pub use zbus;
+    pub use zvariant;
+}
+
 // ============================================================================
 // Public API
 // ============================================================================
@@ -334,7 +344,8 @@ pub mod agent;
 /// and [`connect_vpn`](crate::NetworkManager::connect_vpn). Use these
 /// builders only when you need to feed a raw settings dictionary to
 /// NetworkManager's `AddConnection` or `AddAndActivateConnection` D-Bus
-/// methods directly.
+/// methods directly via [`dbus_connection`](crate::NetworkManager::dbus_connection)
+/// and [`raw`](crate::raw).
 ///
 /// # Example
 ///

--- a/nmrs/src/lib.rs
+++ b/nmrs/src/lib.rs
@@ -138,7 +138,14 @@
 //! NetworkManager settings dictionaries. Most callers should reach for the
 //! higher-level [`NetworkManager`] API; these builders are exposed for
 //! advanced use cases that need to assemble the raw settings dictionary
-//! before calling a D-Bus method directly.
+//! before calling a D-Bus method directly via
+//! [`dbus_connection`](crate::NetworkManager::dbus_connection) and [`raw`](crate::raw).
+//!
+//! ## Raw D-Bus Access
+//!
+//! The [`raw`] module re-exports [`zbus`] and [`zvariant`] so builder output
+//! types stay compatible with the connection returned by
+//! [`NetworkManager::dbus_connection`](crate::NetworkManager::dbus_connection).
 //!
 //! ## Secret Agent
 //!


### PR DESCRIPTION
Add `NetworkManager::dbus_connection()` so advanced callers can use builder output with NetworkManager D-Bus methods on the same bus connection. Re-export zbus and zvariant under `nmrs::raw` and document the builders -> dbus_connection workflow.

Closes #462