### PR TITLE
feat(#260,#463): add high-level add_connection wrappers

### DIFF
--- a/docs/src/advanced/connection-options.md
+++ b/docs/src/advanced/connection-options.md
@@ -86,7 +86,7 @@ let settings = ConnectionBuilder::new("802-11-wireless", "MyNetwork")
     .build();
 ```
 
-The high-level `NetworkManager` API uses `ConnectionOptions::default()` internally. For custom options, build a settings dictionary with the builder APIs and submit it via [`dbus_connection()`](../api/network-manager.md#advanced-d-bus-access). See [Submitting Builder Output](../api/builders.md#submitting-builder-output).
+The high-level `NetworkManager` API uses `ConnectionOptions::default()` internally. For custom options, build a settings dictionary with the builder APIs and submit it via [`add_connection`](../api/network-manager.md#saving-profiles-without-activating) or [`add_and_activate_connection`](../api/network-manager.md#activating-builder-output).
 
 ## Next Steps
 

--- a/docs/src/advanced/dbus.md
+++ b/docs/src/advanced/dbus.md
@@ -40,13 +40,14 @@ This creates a persistent D-Bus connection that's shared across all operations.
 
 For builder workflows and other low-level D-Bus calls, nmrs exposes the same
 connection through [`NetworkManager::dbus_connection()`](../api/network-manager.md#advanced-d-bus-access).
-Pair it with [`nmrs::raw`](../api/raw.md) (`zbus` / `zvariant` re-exports) so
-the types returned by builders are compatible with the connection nmrs manages.
+Pair it with [`nmrs::raw`](../api/raw.md) (`zbus` / `zvariant` re-exports) when
+you need D-Bus methods that nmrs does not wrap yet.
 
-Most applications should keep using the high-level `NetworkManager` methods.
-Reach for `dbus_connection()` only when you need to call NetworkManager D-Bus
-methods that nmrs does not wrap yet (for example `AddAndActivateConnection`
-with custom builder output).
+For builder output, prefer the high-level
+[`add_connection`](../api/network-manager.md#saving-profiles-without-activating)
+and
+[`add_and_activate_connection`](../api/network-manager.md#activating-builder-output)
+methods instead of calling D-Bus directly.
 
 ### Method Calls
 
@@ -106,7 +107,11 @@ methods.
 
 Advanced callers can define their own minimal `#[zbus::proxy]` traits on top of
 [`dbus_connection()`](../api/network-manager.md#advanced-d-bus-access) and
-[`nmrs::raw`](../api/raw.md). See [Submitting Builder Output](../api/builders.md#submitting-builder-output).
+[`nmrs::raw`](../api/raw.md). For builder output, use
+[`add_connection`](../api/network-manager.md#saving-profiles-without-activating)
+or
+[`add_and_activate_connection`](../api/network-manager.md#activating-builder-output)
+first.
 
 ## D-Bus Errors
 

--- a/docs/src/api/builders.md
+++ b/docs/src/api/builders.md
@@ -1,8 +1,8 @@
 # Builders Module
 
-The `builders` module provides low-level APIs for constructing NetworkManager connection settings. Most users should use the high-level `NetworkManager` API instead — these builders are for advanced use cases where you need fine-grained control over the settings dictionary before calling NetworkManager D-Bus methods directly.
+The `builders` module provides low-level APIs for constructing NetworkManager connection settings. Most users should use the high-level `NetworkManager` API instead — these builders are for advanced use cases where you need fine-grained control over the settings dictionary.
 
-To submit builder output, use [`NetworkManager::dbus_connection()`](./network-manager.md#advanced-d-bus-access) together with [`nmrs::raw`](./raw.md) (`zbus` / `zvariant` re-exports). See [Submitting Builder Output](#submitting-builder-output) below.
+To submit builder output, use [`NetworkManager::add_connection`](./network-manager.md#saving-profiles-without-activating) or [`NetworkManager::add_and_activate_connection`](./network-manager.md#activating-builder-output). See [Submitting Builder Output](#submitting-builder-output) below.
 
 ## ConnectionBuilder
 
@@ -153,37 +153,21 @@ For standard connections, the `NetworkManager` API handles everything automatica
 ## Submitting Builder Output
 
 Builders produce a NetworkManager settings dictionary
-(`HashMap<&str, HashMap<&str, zvariant::Value>>`). To activate that profile you
-need the same system D-Bus connection nmrs already manages, plus compatible
-`zbus` / `zvariant` types from [`nmrs::raw`](./raw.md).
+(`HashMap<&str, HashMap<&str, zvariant::Value>>`). Pass that map to
+[`NetworkManager::add_connection`](./network-manager.md#saving-profiles-without-activating)
+to save a profile, or
+[`NetworkManager::add_and_activate_connection`](./network-manager.md#activating-builder-output)
+to create and bring it up immediately.
 
 ### Wi-Fi hotspot (AP mode)
 
-This is the workflow for cases such as [#260](https://github.com/freedesktop-rs/nmrs/issues/260) where the high-level `connect()` API does not expose every builder knob (for example `WifiMode::Ap`):
+This closes the workflow requested in [#260](https://github.com/freedesktop-rs/nmrs/issues/260) — use `WifiMode::Ap` with the high-level API:
 
 ```rust
 use nmrs::builders::{WifiConnectionBuilder, WifiMode};
-use nmrs::raw::{zbus, zvariant};
-use nmrs::{NetworkManager, Result};
+use nmrs::NetworkManager;
 
-#[zbus::proxy(
-    interface = "org.freedesktop.NetworkManager",
-    default_service = "org.freedesktop.NetworkManager",
-    default_path = "/org/freedesktop/NetworkManager"
-)]
-trait Nm {
-    fn add_and_activate_connection(
-        &self,
-        connection: std::collections::HashMap<
-            &str,
-            std::collections::HashMap<&str, zvariant::Value<'_>>,
-        >,
-        device: zvariant::OwnedObjectPath,
-        specific_object: zvariant::OwnedObjectPath,
-    ) -> zbus::Result<(zvariant::OwnedObjectPath, zvariant::OwnedObjectPath)>;
-}
-
-async fn start_hotspot(nm: &NetworkManager, interface: &str) -> Result<()> {
+async fn start_hotspot(nm: &NetworkManager, interface: &str) -> nmrs::Result<()> {
     let settings = WifiConnectionBuilder::new("Hotspot")
         .wpa_psk("password")
         .mode(WifiMode::Ap)
@@ -191,26 +175,38 @@ async fn start_hotspot(nm: &NetworkManager, interface: &str) -> Result<()> {
         .ipv6_ignore()
         .build();
 
-    let device = nm.get_device_by_interface(interface).await?;
-    let proxy = NmProxy::new(nm.dbus_connection()).await?;
-    proxy
-        .add_and_activate_connection(settings, device, "/".into())
-        .await?;
-
+    nm.add_and_activate_connection(settings, Some(interface), None).await?;
     Ok(())
 }
 ```
 
-Notes:
-
-- Use `"/"` as `specific_object` for AP mode and other cases where there is no target access point.
-- For client (infrastructure) mode, resolve an access-point object path first (nmrs does this internally in `connect()`).
-- Map D-Bus errors to `ConnectionError::Dbus` (or handle them in your own error type).
-- nmrs does not yet provide a high-level wrapper for `AddConnection` / `AddAndActivateConnection`; `dbus_connection()` is the supported escape hatch.
+`specific_object` defaults to `"/"`, which is correct for AP mode.
 
 ### Saving without activating
 
-To persist a profile without bringing it up immediately, define a proxy method for `AddConnection` instead and pass the same `settings` map. nmrs uses that D-Bus call internally when saving VPN profiles.
+To persist a profile without bringing it up immediately — the workflow from [#463](https://github.com/freedesktop-rs/nmrs/issues/463):
+
+```rust
+use nmrs::builders::build_wifi_connection;
+use nmrs::{ConnectionOptions, NetworkManager, WifiSecurity};
+
+let nm = NetworkManager::new().await?;
+let settings = build_wifi_connection(
+    "GuestWiFi",
+    &WifiSecurity::WpaPsk { psk: "password".into() },
+    &ConnectionOptions::new(true),
+);
+let profile = nm.add_connection(settings).await?;
+```
+
+Activate the saved profile later with `activate_connection` via D-Bus, or use the existing high-level `connect()` APIs when the profile matches a visible network.
+
+### Advanced: direct D-Bus access
+
+If you need an NetworkManager D-Bus method that nmrs does not wrap yet, combine
+[`dbus_connection()`](./network-manager.md#advanced-d-bus-access) with
+[`nmrs::raw`](./raw.md) and define your own `#[zbus::proxy]` trait on top of
+the builder output.
 
 ## OpenVpnBuilder
 
@@ -254,6 +250,6 @@ See [docs.rs/nmrs](https://docs.rs/nmrs) for complete builder documentation.
 
 ## See Also
 
-- [Raw Module](./raw.md) – `zbus` / `zvariant` re-exports for advanced D-Bus work
-- [NetworkManager API](./network-manager.md#advanced-d-bus-access) – `dbus_connection()`
+- [NetworkManager API](./network-manager.md#activating-builder-output) – `add_connection()` / `add_and_activate_connection()`
+- [Raw Module](./raw.md) – `zbus` / `zvariant` re-exports for unwrapped D-Bus calls
 - [D-Bus Architecture](../advanced/dbus.md) – how settings reach NetworkManager

--- a/docs/src/api/network-manager.md
+++ b/docs/src/api/network-manager.md
@@ -21,6 +21,48 @@ let nm = NetworkManager::with_config(config).await?;
 let config = nm.timeout_config();
 ```
 
+## Saving Profiles Without Activating
+
+```rust
+use nmrs::builders::build_wifi_connection;
+use nmrs::{ConnectionOptions, NetworkManager, WifiSecurity};
+
+let nm = NetworkManager::new().await?;
+let settings = build_wifi_connection(
+    "GuestWiFi",
+    &WifiSecurity::WpaPsk { psk: "password".into() },
+    &ConnectionOptions::new(true),
+);
+let profile = nm.add_connection(settings).await?;
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `add_connection(settings)` | `Result<OwnedObjectPath>` | Save a profile via `Settings.AddConnection` without activating it ([#463](https://github.com/freedesktop-rs/nmrs/issues/463)) |
+
+## Activating Builder Output
+
+```rust
+use nmrs::builders::{WifiConnectionBuilder, WifiMode};
+use nmrs::NetworkManager;
+
+let nm = NetworkManager::new().await?;
+let settings = WifiConnectionBuilder::new("Hotspot")
+    .wpa_psk("password")
+    .mode(WifiMode::Ap)
+    .ipv4_shared()
+    .build();
+
+nm.add_and_activate_connection(settings, Some("wlan0"), None).await?;
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `add_and_activate_connection(settings, interface, specific_object)` | `Result<(OwnedObjectPath, OwnedObjectPath)>` | Create and activate a profile in one step ([#260](https://github.com/freedesktop-rs/nmrs/issues/260)) |
+
+- `interface`: device name such as `"wlan0"`, or `None` to auto-pick the first device matching `connection.type`
+- `specific_object`: access-point path for client Wi-Fi, or `None` for AP mode / Ethernet / VPN (`"/"`)
+
 ## Advanced D-Bus Access
 
 ```rust
@@ -34,8 +76,10 @@ let conn = nm.dbus_connection(); // &zbus::Connection
 | `dbus_connection()` | `&zbus::Connection` | Shared system bus connection for advanced D-Bus calls |
 
 Use this with [`nmrs::raw`](./raw.md) and the [builders](./builders.md) module
-when you need to call NetworkManager methods such as `AddConnection` or
-`AddAndActivateConnection` directly. See [Submitting Builder Output](./builders.md#submitting-builder-output).
+only when you need NetworkManager methods that nmrs does not wrap yet. For
+builder output, prefer
+[`add_connection`](./network-manager.md#saving-profiles-without-activating) and
+[`add_and_activate_connection`](./network-manager.md#activating-builder-output).
 
 ## Wi-Fi Methods
 

--- a/docs/src/api/raw.md
+++ b/docs/src/api/raw.md
@@ -9,7 +9,10 @@ pub mod raw {
 }
 ```
 
-Use it together with [`NetworkManager::dbus_connection()`](./network-manager.md#advanced-d-bus-access) when you need to call NetworkManager D-Bus methods directly — for example after building a settings dictionary with the [`builders`](./builders.md) module.
+Use it together with [`NetworkManager::dbus_connection()`](./network-manager.md#advanced-d-bus-access)
+when you need D-Bus methods that nmrs does not wrap yet. For builder output,
+prefer [`add_connection`](./network-manager.md#saving-profiles-without-activating)
+and [`add_and_activate_connection`](./network-manager.md#activating-builder-output).
 
 ## Why it exists
 
@@ -28,8 +31,8 @@ output and with the connection returned by `dbus_connection()`.
 3. Create a zbus proxy on that connection using `nmrs::raw::zbus`.
 4. Call `AddConnection` or `AddAndActivateConnection` on NetworkManager.
 
-See [Submitting Builder Output](./builders.md#submitting-builder-output) for a
-full Wi-Fi hotspot example and [D-Bus Architecture](../advanced/dbus.md) for
+See [Submitting Builder Output](./builders.md#submitting-builder-output) for the
+preferred high-level workflow and [D-Bus Architecture](../advanced/dbus.md) for
 background on how nmrs talks to NetworkManager.
 
 ## What is not exposed

--- a/nmrs/CHANGELOG.md
+++ b/nmrs/CHANGELOG.md
@@ -7,7 +7,8 @@ All notable changes to the `nmrs` crate will be documented in this file.
 - Expose existing secrets on SecretRequest for re-auth prefill ([#460](https://github.com/freedesktop-rs/nmrs/pull/460))
 - `MonitorHandle` returned by `monitor_network_changes` and `monitor_device_changes` for graceful shutdown ([#461](https://github.com/freedesktop-rs/nmrs/pull/461))
 - `NetworkManager::dbus_connection()` and `nmrs::raw` (`zbus` / `zvariant` re-exports) for advanced builder workflows ([#462](https://github.com/freedesktop-rs/nmrs/pull/464))
-- mdbook docs for `dbus_connection()`, `nmrs::raw`, and submitting builder output ([#462](https://github.com/freedesktop-rs/nmrs/pull/464))
+- `NetworkManager::add_connection()` and `NetworkManager::add_and_activate_connection()` for submitting builder output without custom zbus proxies ([#260](https://github.com/freedesktop-rs/nmrs/issues/260), [#465](https://github.com/freedesktop-rs/nmrs/pull/465))
+- mdbook docs for builder submission workflow, `add_connection()`, and `add_and_activate_connection()` ([#462](https://github.com/freedesktop-rs/nmrs/pull/464))
 
 ### Fixed
 - `monitor_network_changes` now detects hotplugged Wi-Fi devices instead of only monitoring devices present at startup ([#461](https://github.com/freedesktop-rs/nmrs/pull/461))

--- a/nmrs/src/api/builders/mod.rs
+++ b/nmrs/src/api/builders/mod.rs
@@ -35,8 +35,10 @@
 //! need fine-grained control over the raw settings dictionary before
 //! handing it to NetworkManager's `AddConnection` or
 //! `AddAndActivateConnection` D-Bus methods via
-//! [`NetworkManager::dbus_connection`](crate::NetworkManager::dbus_connection)
-//! and [`raw`](crate::raw).
+//! [`NetworkManager::add_connection`](crate::NetworkManager::add_connection),
+//! [`NetworkManager::add_and_activate_connection`](crate::NetworkManager::add_and_activate_connection),
+//! [`NetworkManager::dbus_connection`](crate::NetworkManager::dbus_connection),
+//! or [`raw`](crate::raw).
 //!
 //! # Examples
 //!
@@ -71,8 +73,7 @@
 //!     .build();
 //!
 //! let _conn = nm.dbus_connection();
-//! // Use `settings` with NetworkManager's AddAndActivateConnection on `_conn`
-//! // via `nmrs::raw::zbus` proxies.
+//! // Prefer `nm.add_and_activate_connection(settings, Some("wlan0"), None)` instead.
 //! # Ok(())
 //! # }
 //! ```
@@ -98,9 +99,9 @@
 //!     .expect("WireGuardBuilder is fully configured");
 //! ```
 //!
-//! The returned settings can then be passed to NetworkManager's
-//! `AddConnection` or `AddAndActivateConnection` D-Bus methods through
-//! [`NetworkManager::dbus_connection`](crate::NetworkManager::dbus_connection).
+//! The returned settings can then be passed to
+//! [`NetworkManager::add_connection`](crate::NetworkManager::add_connection) or
+//! [`NetworkManager::add_and_activate_connection`](crate::NetworkManager::add_and_activate_connection).
 
 pub mod bluetooth;
 pub mod connection_builder;

--- a/nmrs/src/api/network_manager.rs
+++ b/nmrs/src/api/network_manager.rs
@@ -27,6 +27,10 @@ use crate::core::connection::{
 use crate::core::connection_settings::{
     get_saved_connection_path, get_saved_connection_uuid, has_saved_connection,
 };
+use crate::core::custom_connection::{
+    add_and_activate_connection as add_and_activate_profile,
+    add_connection as add_connection_profile,
+};
 use crate::core::device::{
     is_connecting, list_bluetooth_devices, list_devices, list_wired_device_details,
     wait_for_wifi_ready,
@@ -236,10 +240,11 @@ impl NetworkManager {
 
     /// Returns the underlying system D-Bus connection.
     ///
-    /// Advanced callers can use this together with [`builders`](crate::builders)
-    /// and [`raw`](crate::raw) to invoke NetworkManager D-Bus methods such as
-    /// `AddConnection` or `AddAndActivateConnection` on the same connection
-    /// managed by this [`NetworkManager`] instance.
+    /// Most callers should prefer [`add_connection`](Self::add_connection) and
+    /// [`add_and_activate_connection`](Self::add_and_activate_connection) over
+    /// invoking D-Bus methods directly. Use this accessor together with
+    /// [`builders`](crate::builders) and [`raw`](crate::raw) only when you
+    /// need NetworkManager D-Bus calls that nmrs does not wrap yet.
     ///
     /// # Examples
     ///
@@ -255,14 +260,107 @@ impl NetworkManager {
     ///     .ipv4_shared()
     ///     .build();
     ///
+    /// // Prefer the high-level API:
+    /// nm.add_and_activate_connection(settings, Some("wlan0"), None).await?;
+    ///
+    /// // Or access the raw connection for unwrapped D-Bus calls:
     /// let _conn = nm.dbus_connection();
-    /// // Pass `settings` to NetworkManager's AddAndActivateConnection via
-    /// // `nmrs::raw::zbus` proxies on `_conn`.
     /// # Ok(())
     /// # }
     /// ```
     pub fn dbus_connection(&self) -> &Connection {
         &self.conn
+    }
+
+    /// Saves a connection profile without activating it.
+    ///
+    /// Wraps NetworkManager's `Settings.AddConnection` D-Bus method. Pass a
+    /// settings dictionary produced by the [`builders`](crate::builders) module
+    /// or [`NetworkManager::connect`](Self::connect)'s internal builders.
+    ///
+    /// Returns the D-Bus object path of the new saved profile.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use nmrs::builders::{build_wifi_connection, WifiConnectionBuilder, WifiMode};
+    /// use nmrs::{ConnectionOptions, NetworkManager, WifiSecurity};
+    ///
+    /// # async fn example() -> nmrs::Result<()> {
+    /// let nm = NetworkManager::new().await?;
+    ///
+    /// // Save a client profile for later activation.
+    /// let opts = ConnectionOptions::new(true);
+    /// let settings = build_wifi_connection(
+    ///     "GuestWiFi",
+    ///     &WifiSecurity::WpaPsk { psk: "password".into() },
+    ///     &opts,
+    /// );
+    /// let profile = nm.add_connection(settings).await?;
+    /// println!("Saved profile at {}", profile.as_str());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn add_connection(
+        &self,
+        settings: HashMap<&str, HashMap<&str, zvariant::Value<'_>>>,
+    ) -> Result<zvariant::OwnedObjectPath> {
+        add_connection_profile(&self.conn, settings).await
+    }
+
+    /// Creates a connection profile and activates it in one step.
+    ///
+    /// Wraps NetworkManager's `AddAndActivateConnection` D-Bus method. This is
+    /// the supported way to use builder output for cases such as Wi-Fi AP/hotspot
+    /// mode that are not covered by [`connect`](Self::connect).
+    ///
+    /// # Arguments
+    ///
+    /// * `settings` — connection settings dictionary from a builder
+    /// * `interface` — network device to use (for example `"wlan0"`). When
+    ///   `None`, nmrs picks the first device matching `connection.type`
+    /// * `specific_object` — optional target object path. Use `None` for AP
+    ///   mode, Ethernet, and VPN profiles (`"/"`). For client Wi-Fi, pass the
+    ///   access-point object path.
+    ///
+    /// Returns the saved profile path and active-connection path.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use nmrs::builders::{WifiConnectionBuilder, WifiMode};
+    /// use nmrs::NetworkManager;
+    ///
+    /// # async fn example() -> nmrs::Result<()> {
+    /// let nm = NetworkManager::new().await?;
+    /// let settings = WifiConnectionBuilder::new("Hotspot")
+    ///     .wpa_psk("password")
+    ///     .mode(WifiMode::Ap)
+    ///     .ipv4_shared()
+    ///     .ipv6_ignore()
+    ///     .build();
+    ///
+    /// let (profile, active) =
+    ///     nm.add_and_activate_connection(settings, Some("wlan0"), None).await?;
+    /// println!("Profile: {}, active: {}", profile.as_str(), active.as_str());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn add_and_activate_connection(
+        &self,
+        settings: HashMap<&str, HashMap<&str, zvariant::Value<'_>>>,
+        interface: Option<&str>,
+        specific_object: Option<&str>,
+    ) -> Result<(zvariant::OwnedObjectPath, zvariant::OwnedObjectPath)> {
+        let _guard = self.connect_guard.lock().await;
+        add_and_activate_profile(
+            &self.conn,
+            settings,
+            interface,
+            specific_object,
+            self.timeout_config,
+        )
+        .await
     }
 
     /// List all network devices managed by NetworkManager.

--- a/nmrs/src/core/custom_connection.rs
+++ b/nmrs/src/core/custom_connection.rs
@@ -1,0 +1,224 @@
+//! Submitting builder-produced connection settings to NetworkManager.
+//!
+//! Wraps the `AddConnection` and `AddAndActivateConnection` D-Bus methods so
+//! callers can use [`builders`](crate::api::builders) output without writing
+//! their own zbus proxies.
+
+use std::collections::HashMap;
+
+use log::debug;
+use zbus::Connection;
+use zvariant::{OwnedObjectPath, Value};
+
+use crate::Result;
+use crate::api::models::{ConnectionError, TimeoutConfig};
+use crate::core::connection::{disconnect_wifi_and_wait, get_device_by_interface};
+use crate::core::state_wait::wait_for_connection_activation;
+use crate::dbus::{NMDeviceProxy, NMProxy};
+use crate::types::constants::device_type;
+use crate::util::utils::{bluez_device_path, settings_proxy};
+
+fn connection_type_from_settings<'a>(
+    settings: &'a HashMap<&str, HashMap<&str, Value<'_>>>,
+) -> Result<&'a str> {
+    settings
+        .get("connection")
+        .and_then(|section| section.get("type"))
+        .and_then(|value| match value {
+            Value::Str(conn_type) => Some(conn_type.as_str()),
+            _ => None,
+        })
+        .ok_or_else(|| ConnectionError::InvalidInput {
+            field: "connection.type".into(),
+            reason: "settings dictionary is missing connection.type".into(),
+        })
+}
+
+fn expected_device_type(conn_type: &str) -> Option<u32> {
+    match conn_type {
+        "802-11-wireless" => Some(device_type::WIFI),
+        "802-3-ethernet" => Some(device_type::ETHERNET),
+        "bluetooth" => Some(device_type::BLUETOOTH),
+        _ => None,
+    }
+}
+
+async fn find_first_device_by_type(conn: &Connection, raw_type: u32) -> Result<OwnedObjectPath> {
+    let nm = NMProxy::new(conn).await?;
+    let devices = nm.get_devices().await?;
+
+    for dev_path in devices {
+        let dev = NMDeviceProxy::builder(conn)
+            .path(dev_path.clone())?
+            .build()
+            .await?;
+
+        if dev.device_type().await? == raw_type {
+            debug!(
+                "Resolved device {} for connection type {}",
+                dev.interface().await.unwrap_or_default(),
+                raw_type
+            );
+            return Ok(dev_path);
+        }
+    }
+
+    Err(ConnectionError::NotFound)
+}
+
+async fn resolve_device_path(
+    conn: &Connection,
+    settings: &HashMap<&str, HashMap<&str, Value<'_>>>,
+    interface: Option<&str>,
+) -> Result<OwnedObjectPath> {
+    if let Some(iface) = interface {
+        return get_device_by_interface(conn, iface).await;
+    }
+
+    let conn_type = connection_type_from_settings(settings)?;
+    match expected_device_type(conn_type) {
+        Some(raw_type) => find_first_device_by_type(conn, raw_type).await,
+        None => Ok(OwnedObjectPath::default()),
+    }
+}
+
+fn bluetooth_bdaddr_from_settings(
+    settings: &HashMap<&str, HashMap<&str, Value<'_>>>,
+) -> Result<String> {
+    settings
+        .get("bluetooth")
+        .and_then(|section| section.get("bdaddr"))
+        .and_then(|value| match value {
+            Value::Str(bdaddr) => Some(bdaddr.as_str().to_string()),
+            _ => None,
+        })
+        .ok_or_else(|| ConnectionError::InvalidInput {
+            field: "bluetooth.bdaddr".into(),
+            reason: "bluetooth settings are missing bdaddr".into(),
+        })
+}
+
+fn resolve_specific_object(
+    settings: &HashMap<&str, HashMap<&str, Value<'_>>>,
+    specific_object: Option<&str>,
+) -> Result<OwnedObjectPath> {
+    if let Some(path) = specific_object {
+        return OwnedObjectPath::try_from(path).map_err(|e| ConnectionError::InvalidInput {
+            field: "specific_object".into(),
+            reason: e.to_string(),
+        });
+    }
+
+    if connection_type_from_settings(settings)? == "bluetooth" {
+        let bdaddr = bluetooth_bdaddr_from_settings(settings)?;
+        return OwnedObjectPath::try_from(bluez_device_path(&bdaddr, None)).map_err(|e| {
+            ConnectionError::InvalidInput {
+                field: "specific_object".into(),
+                reason: e.to_string(),
+            }
+        });
+    }
+
+    Ok(OwnedObjectPath::default())
+}
+
+/// Saves a connection profile without activating it (`Settings.AddConnection`).
+pub(crate) async fn add_connection(
+    conn: &Connection,
+    settings: HashMap<&str, HashMap<&str, Value<'_>>>,
+) -> Result<OwnedObjectPath> {
+    let settings_api = settings_proxy(conn).await?;
+    let add_reply = settings_api
+        .call_method("AddConnection", &(settings,))
+        .await
+        .map_err(|e| ConnectionError::DbusOperation {
+            context: "failed to add connection".into(),
+            source: e,
+        })?;
+
+    add_reply
+        .body()
+        .deserialize()
+        .map_err(|e| ConnectionError::DbusOperation {
+            context: "failed to decode AddConnection reply".into(),
+            source: e,
+        })
+}
+
+/// Creates and activates a connection in one step (`AddAndActivateConnection`).
+pub(crate) async fn add_and_activate_connection(
+    conn: &Connection,
+    settings: HashMap<&str, HashMap<&str, Value<'_>>>,
+    interface: Option<&str>,
+    specific_object: Option<&str>,
+    timeout_config: TimeoutConfig,
+) -> Result<(OwnedObjectPath, OwnedObjectPath)> {
+    let device = resolve_device_path(conn, &settings, interface).await?;
+    let specific_object = resolve_specific_object(&settings, specific_object)?;
+
+    if device.as_str() != "/" {
+        disconnect_wifi_and_wait(conn, &device, Some(timeout_config)).await?;
+    }
+
+    let nm = NMProxy::new(conn).await?;
+    let (profile_path, active_path) = nm
+        .add_and_activate_connection(settings, device, specific_object)
+        .await?;
+
+    wait_for_connection_activation(conn, &active_path, Some(timeout_config.connection_timeout))
+        .await?;
+
+    Ok((profile_path, active_path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zvariant::Value;
+
+    fn sample_wifi_settings() -> HashMap<&'static str, HashMap<&'static str, Value<'static>>> {
+        let mut connection = HashMap::new();
+        connection.insert("type", Value::from("802-11-wireless"));
+        connection.insert("id", Value::from("Hotspot"));
+
+        let mut wireless = HashMap::new();
+        wireless.insert("mode", Value::from("ap"));
+
+        let mut settings = HashMap::new();
+        settings.insert("connection", connection);
+        settings.insert("802-11-wireless", wireless);
+        settings
+    }
+
+    #[test]
+    fn connection_type_from_settings_reads_type_field() {
+        let settings = sample_wifi_settings();
+        assert_eq!(
+            connection_type_from_settings(&settings).unwrap(),
+            "802-11-wireless"
+        );
+    }
+
+    #[test]
+    fn connection_type_from_settings_requires_type_field() {
+        let settings = HashMap::new();
+        let err = connection_type_from_settings(&settings).unwrap_err();
+        assert!(matches!(err, ConnectionError::InvalidInput { .. }));
+    }
+
+    #[test]
+    fn resolve_specific_object_defaults_to_root_path() {
+        let settings = sample_wifi_settings();
+        let path = resolve_specific_object(&settings, None).unwrap();
+        assert_eq!(path.as_str(), "/");
+    }
+
+    #[test]
+    fn resolve_specific_object_parses_explicit_path() {
+        let settings = sample_wifi_settings();
+        let path =
+            resolve_specific_object(&settings, Some("/org/freedesktop/NetworkManager/Devices/3"))
+                .unwrap();
+        assert_eq!(path.as_str(), "/org/freedesktop/NetworkManager/Devices/3");
+    }
+}

--- a/nmrs/src/core/mod.rs
+++ b/nmrs/src/core/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod bluetooth;
 pub(crate) mod connection;
 pub(crate) mod connection_settings;
 pub(crate) mod connectivity;
+pub(crate) mod custom_connection;
 pub(crate) mod device;
 pub(crate) mod ovpn_parser;
 pub(crate) mod rfkill;

--- a/nmrs/src/lib.rs
+++ b/nmrs/src/lib.rs
@@ -139,7 +139,9 @@
 //! higher-level [`NetworkManager`] API; these builders are exposed for
 //! advanced use cases that need to assemble the raw settings dictionary
 //! before calling a D-Bus method directly via
-//! [`dbus_connection`](crate::NetworkManager::dbus_connection) and [`raw`](crate::raw).
+//! [`add_connection`](crate::NetworkManager::add_connection),
+//! [`add_and_activate_connection`](crate::NetworkManager::add_and_activate_connection),
+//! [`dbus_connection`](crate::NetworkManager::dbus_connection), or [`raw`](crate::raw).
 //!
 //! ## Raw D-Bus Access
 //!
@@ -350,9 +352,9 @@ pub mod raw {
 /// high-level methods such as [`connect`](crate::NetworkManager::connect)
 /// and [`connect_vpn`](crate::NetworkManager::connect_vpn). Use these
 /// builders only when you need to feed a raw settings dictionary to
-/// NetworkManager's `AddConnection` or `AddAndActivateConnection` D-Bus
-/// methods directly via [`dbus_connection`](crate::NetworkManager::dbus_connection)
-/// and [`raw`](crate::raw).
+/// NetworkManager via [`add_connection`](crate::NetworkManager::add_connection),
+/// [`add_and_activate_connection`](crate::NetworkManager::add_and_activate_connection),
+/// [`dbus_connection`](crate::NetworkManager::dbus_connection), or [`raw`](crate::raw).
 ///
 /// # Example
 ///


### PR DESCRIPTION
Expose NetworkManager::add_connection() and add_and_activate_connection() so builder output can be submitted without custom zbus proxies. Update mdbook and rustdoc to document AP hotspot and save-without-activate flows.

Closes #463
Closes #260 