### PR TITLE
feat(#482): add ap mode display test case

### DIFF
--- a/nmrs/src/api/models/access_point.rs
+++ b/nmrs/src/api/models/access_point.rs
@@ -370,6 +370,15 @@ mod tests {
     }
 
     #[test]
+    fn ap_mode_display() {
+        assert_eq!(ApMode::Adhoc.to_string(), "Ad-Hoc");
+        assert_eq!(ApMode::Infrastructure.to_string(), "Infrastructure");
+        assert_eq!(ApMode::Ap.to_string(), "AP");
+        assert_eq!(ApMode::Mesh.to_string(), "Mesh");
+        assert_eq!(ApMode::Unknown(42).to_string(), "Unknown(42)");
+    }
+
+    #[test]
     fn connect_type_display() {
         assert_eq!(ConnectType::Open.to_string(), "Open");
         assert_eq!(ConnectType::Psk.to_string(), "PSK");


### PR DESCRIPTION
Added unit test coverage for access_point ApMode.
Closes #482 