### PR TITLE
refactor(logging): downgrade high-frequency and noisy logs to trace

### DIFF
--- a/nmrs/src/agent/iface.rs
+++ b/nmrs/src/agent/iface.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 use futures::SinkExt;
 use futures::channel::{mpsc, oneshot};
 use futures::future::{self, Either};
-use log::{debug, warn};
+use log::{debug, trace, warn};
 use zvariant::{ObjectPath, OwnedObjectPath};
 
 use crate::types::constants::timeouts;
@@ -170,7 +170,7 @@ impl SecretAgentInterface {
         _connection: ConnectionDict,
         connection_path: ObjectPath<'_>,
     ) -> Result<(), SecretAgentDBusError> {
-        debug!("SaveSecrets: path={}", connection_path);
+        trace!("SaveSecrets: path={}", connection_path);
         let _ = self.store_tx.unbounded_send(SecretStoreEvent::Save {
             connection_path: connection_path.into(),
         });
@@ -183,7 +183,7 @@ impl SecretAgentInterface {
         _connection: ConnectionDict,
         connection_path: ObjectPath<'_>,
     ) -> Result<(), SecretAgentDBusError> {
-        debug!("DeleteSecrets: path={}", connection_path);
+        trace!("DeleteSecrets: path={}", connection_path);
         let _ = self.store_tx.unbounded_send(SecretStoreEvent::Delete {
             connection_path: connection_path.into(),
         });

--- a/nmrs/src/core/bluetooth.rs
+++ b/nmrs/src/core/bluetooth.rs
@@ -6,7 +6,7 @@
 //! Similar to other device types, it handles scanning, connecting, and monitoring
 //! Bluetooth devices using NetworkManager's D-Bus API.
 
-use log::debug;
+use log::{debug, trace};
 use zbus::Connection;
 use zvariant::OwnedObjectPath;
 // use futures_timer::Delay;
@@ -131,14 +131,14 @@ pub(crate) async fn connect_bluetooth(
             return Ok(());
         }
     } else {
-        debug!("Not currently connected to any Bluetooth device");
+        trace!("Not currently connected to any Bluetooth device");
     }
 
     // Find the Bluetooth hardware adapter
     // Note: Unlike WiFi, Bluetooth connections in NetworkManager don't require
     // specifying a specific device. We use "/" to let NetworkManager auto-select.
     let bt_device = find_bluetooth_device(conn, &nm).await?;
-    debug!("Using auto-select device path for Bluetooth connection");
+    trace!("Using auto-select device path for Bluetooth connection");
 
     // Check for saved connection
     let saved = get_saved_connection_path(conn, name).await?;
@@ -173,7 +173,7 @@ pub(crate) async fn connect_bluetooth(
 
             let connection_settings = bluetooth::build_bluetooth_connection(name, settings, &opts);
 
-            debug!(
+            trace!(
                 "Creating Bluetooth connection with settings: {:#?}",
                 connection_settings
             );
@@ -223,7 +223,7 @@ pub(crate) async fn disconnect_bluetooth_and_wait(
         .build()
         .await?;
 
-    debug!("Sending disconnect request to Bluetooth device");
+    trace!("Sending disconnect request to Bluetooth device");
     raw.call_method("Disconnect", &()).await?;
 
     // Wait for disconnect using signal-based monitoring

--- a/nmrs/src/core/connection.rs
+++ b/nmrs/src/core/connection.rs
@@ -1,5 +1,5 @@
 use futures_timer::Delay;
-use log::{debug, error, info, warn};
+use log::{debug, error, info, trace, warn};
 use std::collections::HashMap;
 use zbus::Connection;
 use zvariant::OwnedObjectPath;
@@ -62,7 +62,7 @@ pub(crate) async fn connect(
     let decision = decide_saved_connection(saved_raw, &creds)?;
 
     let wifi_device = resolve_wifi_device(conn, &nm, interface).await?;
-    debug!("Resolved WiFi device: {}", wifi_device.as_str());
+    trace!("Resolved WiFi device: {}", wifi_device.as_str());
 
     let wifi = NMWirelessProxy::builder(conn)
         .path(wifi_device.clone())?
@@ -76,7 +76,7 @@ pub(crate) async fn connect(
             return Ok(());
         }
     } else {
-        debug!("Not currently connected to any network");
+        trace!("Not currently connected to any network");
     }
 
     let specific_object = scan_and_resolve_ap(conn, &wifi, ssid).await?;
@@ -135,7 +135,7 @@ pub(crate) async fn connect_wired(
     let nm = NMProxy::new(conn).await?;
 
     let wired_device = find_wired_device(conn, &nm).await?;
-    debug!("Found wired device: {}", wired_device.as_str());
+    trace!("Found wired device: {}", wired_device.as_str());
 
     // Check if already connected
     let dev = NMDeviceProxy::builder(conn)
@@ -277,7 +277,7 @@ pub(crate) async fn forget_by_name_and_type(
                         }
                         debug!("Device confirmed disconnected, proceeding with deletion");
                     }
-                    debug!("WiFi disconnect phase completed");
+                    trace!("WiFi disconnect phase completed");
                 }
             }
         }
@@ -307,13 +307,13 @@ pub(crate) async fn forget_by_name_and_type(
                         )));
                     }
                 }
-                debug!("Bluetooth disconnect phase completed");
+                trace!("Bluetooth disconnect phase completed");
             }
         }
     }
 
     // Delete connection profiles (generic, works for all types)
-    debug!("Starting connection deletion phase...");
+    trace!("Starting connection deletion phase...");
 
     let settings = nm_proxy(
         conn,
@@ -347,7 +347,7 @@ pub(crate) async fn forget_by_name_and_type(
                 && id.as_str() == name
             {
                 should_delete = true;
-                debug!("Found connection by ID: {id}");
+                trace!("Found connection by ID: {id}");
             }
 
             // Additional WiFi-specific matching by SSID
@@ -362,7 +362,7 @@ pub(crate) async fn forget_by_name_and_type(
                 }
                 if decode_ssid_or_empty(&raw) == name {
                     should_delete = true;
-                    debug!("Found WiFi connection by SSID match");
+                    trace!("Found WiFi connection by SSID match");
                 }
             }
 
@@ -372,7 +372,7 @@ pub(crate) async fn forget_by_name_and_type(
                 && bdaddr.as_str() == name
             {
                 should_delete = true;
-                debug!("Found Bluetooth connection by bdaddr match");
+                trace!("Found Bluetooth connection by bdaddr match");
             }
 
             if let Some(wsec) = settings_map.get("802-11-wireless-security") {
@@ -380,7 +380,7 @@ pub(crate) async fn forget_by_name_and_type(
                 let empty_psk = matches!(wsec.get("psk"), Some(Value::Str(s)) if s.is_empty());
 
                 if (missing_psk || empty_psk) && should_delete {
-                    debug!("Connection has missing/empty PSK, will delete");
+                    trace!("Connection has missing/empty PSK, will delete");
                 }
             }
 
@@ -388,7 +388,7 @@ pub(crate) async fn forget_by_name_and_type(
                 match cproxy.call_method("Delete", &()).await {
                     Ok(_) => {
                         deleted_count += 1;
-                        debug!("Deleted connection: {}", cpath.as_str());
+                        trace!("Deleted connection: {}", cpath.as_str());
                     }
                     Err(e) => {
                         warn!("Failed to delete connection {}: {}", cpath.as_str(), e);
@@ -446,9 +446,9 @@ pub(crate) async fn disconnect_wifi_and_wait(
     )
     .await?;
 
-    debug!("Sending disconnect request");
+    trace!("Sending disconnect request");
     raw.call_method("Disconnect", &()).await?;
-    debug!("Disconnect method called successfully");
+    trace!("Disconnect method called successfully");
 
     // Wait for disconnect using signal-based monitoring
     let timeout = timeout_config.map(|c| c.disconnect_timeout);
@@ -644,7 +644,7 @@ pub(crate) async fn connect_to_bssid(
                 .await?;
 
             match wifi.request_scan(HashMap::new()).await {
-                Ok(_) => debug!("Scan requested successfully"),
+                Ok(_) => trace!("Scan requested successfully"),
                 Err(e) => warn!("Scan request failed: {e}"),
             }
             futures_timer::Delay::new(timeouts::scan_wait()).await;
@@ -721,7 +721,7 @@ async fn connect_via_saved(
         .await
     {
         Ok(active_conn) => {
-            debug!(
+            trace!(
                 "activate_connection() succeeded, active connection: {}",
                 active_conn.as_str()
             );
@@ -826,7 +826,7 @@ async fn build_and_activate_new(
 
     let settings = build_wifi_connection(ssid, &creds, &opts);
 
-    debug!("Creating new connection, settings: \n{settings:#?}");
+    trace!("Creating new connection, settings: \n{settings:#?}");
 
     ensure_disconnected(conn, wifi_device, timeout_config).await?;
 
@@ -835,7 +835,7 @@ async fn build_and_activate_new(
         .await
     {
         Ok(paths) => {
-            debug!(
+            trace!(
                 "add_and_activate_connection() succeeded, active connection: {}",
                 paths.1.as_str()
             );
@@ -847,7 +847,7 @@ async fn build_and_activate_new(
         }
     };
 
-    debug!("Waiting for connection activation using signal monitoring...");
+    trace!("Waiting for connection activation using signal monitoring...");
 
     // Wait for connection activation using the ActiveConnection signals
     let timeout = timeout_config.map(|c| c.connection_timeout);
@@ -870,16 +870,16 @@ async fn scan_and_resolve_ap(
     ssid: &str,
 ) -> Result<OwnedObjectPath> {
     match wifi.request_scan(HashMap::new()).await {
-        Ok(_) => debug!("Scan requested successfully"),
+        Ok(_) => trace!("Scan requested successfully"),
         Err(e) => warn!("Scan request failed: {e}"),
     }
 
     // Brief wait for scan results to populate
     Delay::new(timeouts::scan_wait()).await;
-    debug!("Scan wait complete");
+    trace!("Scan wait complete");
 
     let ap = find_ap(conn, wifi, ssid).await?;
-    debug!("Matched target SSID '{ssid}'");
+    trace!("Matched target SSID '{ssid}'");
     Ok(ap)
 }
 
@@ -923,7 +923,7 @@ pub(crate) async fn is_connected(conn: &Connection, ssid: &str) -> Result<bool> 
             return Ok(true);
         }
     } else {
-        debug!("Not currently connected to any network");
+        trace!("Not currently connected to any network");
     }
     Ok(false)
 }
@@ -982,7 +982,7 @@ pub(crate) async fn disconnect(
                 continue;
             }
             match nm.deactivate_connection(conn_path.clone()).await {
-                Ok(_) => debug!("Connection deactivated"),
+                Ok(_) => trace!("Connection deactivated"),
                 Err(e) => warn!("Failed to deactivate connection: {}", e),
             }
         }
@@ -1013,7 +1013,7 @@ pub(crate) async fn get_device_by_interface(
         if let Ok(iface) = dev.interface().await
             && iface == interface_name
         {
-            debug!("Found device with interface: {}", interface_name);
+            trace!("Found device with interface: {}", interface_name);
             return Ok(dev_path);
         }
     }

--- a/nmrs/src/core/connection_settings.rs
+++ b/nmrs/src/core/connection_settings.rs
@@ -4,7 +4,7 @@
 //! connection profiles. Saved connections persist across reboots and
 //! store credentials for automatic reconnection.
 
-use log::debug;
+use log::trace;
 use std::collections::HashMap;
 use zbus::Connection;
 use zvariant::{OwnedObjectPath, Value};
@@ -129,7 +129,7 @@ pub(crate) async fn delete_connection(conn: &Connection, conn_path: OwnedObjectP
             source: e,
         })?;
 
-    debug!("Deleted connection: {}", conn_path.as_str());
+    trace!("Deleted connection: {}", conn_path.as_str());
     Ok(())
 }
 

--- a/nmrs/src/core/connectivity.rs
+++ b/nmrs/src/core/connectivity.rs
@@ -1,6 +1,6 @@
 //! Connectivity state reads and captive-portal URL discovery.
 
-use log::debug;
+use log::trace;
 use zbus::Connection;
 
 use crate::Result;
@@ -110,7 +110,7 @@ async fn try_ip4_captive_portal(
         if let Ok(v) = raw.get_property::<String>(prop).await
             && !v.is_empty()
         {
-            debug!("captive portal URL from IP4Config.{prop}: {v}");
+            trace!("captive portal URL from IP4Config.{prop}: {v}");
             return Some(v);
         }
     }

--- a/nmrs/src/core/custom_connection.rs
+++ b/nmrs/src/core/custom_connection.rs
@@ -6,7 +6,7 @@
 
 use std::collections::HashMap;
 
-use log::debug;
+use log::trace;
 use zbus::Connection;
 use zvariant::{OwnedObjectPath, Value};
 
@@ -54,7 +54,7 @@ async fn find_first_device_by_type(conn: &Connection, raw_type: u32) -> Result<O
             .await?;
 
         if dev.device_type().await? == raw_type {
-            debug!(
+            trace!(
                 "Resolved device {} for connection type {}",
                 dev.interface().await.unwrap_or_default(),
                 raw_type

--- a/nmrs/src/core/device.rs
+++ b/nmrs/src/core/device.rs
@@ -4,7 +4,7 @@
 //! and enabling/disabling Wi-Fi. Uses D-Bus signals for efficient state
 //! monitoring instead of polling.
 
-use log::{debug, warn};
+use log::{debug, trace, warn};
 use zbus::Connection;
 
 use crate::Result;
@@ -71,7 +71,7 @@ pub(crate) async fn list_devices(conn: &Connection) -> Result<Vec<Device>> {
         let perm_mac = match d_proxy.perm_hw_address().await {
             Ok(addr) => addr,
             Err(e) => {
-                debug!(
+                trace!(
                     "Permanent hardware address not available for device {}: {}",
                     interface, e
                 );
@@ -85,7 +85,7 @@ pub(crate) async fn list_devices(conn: &Connection) -> Result<Vec<Device>> {
         let managed = match d_proxy.managed().await {
             Ok(m) => Some(m),
             Err(e) => {
-                debug!(
+                trace!(
                     "Failed to get 'managed' property for device {}: {}",
                     interface, e
                 );
@@ -95,7 +95,7 @@ pub(crate) async fn list_devices(conn: &Connection) -> Result<Vec<Device>> {
         let driver = match d_proxy.driver().await {
             Ok(d) => Some(d),
             Err(e) => {
-                debug!("Failed to get driver for device {}: {}", interface, e);
+                trace!("Failed to get driver for device {}: {}", interface, e);
                 None
             }
         };
@@ -114,19 +114,19 @@ pub(crate) async fn list_devices(conn: &Connection) -> Result<Vec<Device>> {
                         {
                             Ok(ap) => ap.frequency().await.ok(),
                             Err(e) => {
-                                debug!("Failed to build active AP proxy for {}: {}", interface, e);
+                                trace!("Failed to build active AP proxy for {}: {}", interface, e);
                                 None
                             }
                         }
                     }
                     Ok(_) => None,
                     Err(e) => {
-                        debug!("Failed to get active AP for {}: {}", interface, e);
+                        trace!("Failed to get active AP for {}: {}", interface, e);
                         None
                     }
                 },
                 Err(e) => {
-                    debug!("Failed to build wireless proxy for {}: {}", interface, e);
+                    trace!("Failed to build wireless proxy for {}: {}", interface, e);
                     None
                 }
             }

--- a/nmrs/src/core/state_wait.rs
+++ b/nmrs/src/core/state_wait.rs
@@ -20,7 +20,7 @@
 
 use futures::{FutureExt, StreamExt, select};
 use futures_timer::Delay;
-use log::{debug, warn};
+use log::{debug, trace, warn};
 use std::pin::pin;
 use std::time::Duration;
 use zbus::Connection;
@@ -85,12 +85,12 @@ pub(crate) async fn wait_for_connection_activation(
 
     // Subscribe to signals FIRST to avoid race condition
     let mut stream = active_conn.receive_activation_state_changed().await?;
-    debug!("Subscribed to ActiveConnection StateChanged signal");
+    trace!("Subscribed to ActiveConnection StateChanged signal");
 
     // Check current state - if already terminal, return immediately
     let current_state = active_conn.state().await?;
     let state = ActiveConnectionState::from(current_state);
-    debug!("Current active connection state: {state}");
+    trace!("Current active connection state: {state}");
 
     match state {
         ActiveConnectionState::Activated => {
@@ -137,11 +137,11 @@ pub(crate) async fn wait_for_connection_activation(
                             Ok(args) => {
                                 let new_state = ActiveConnectionState::from(args.state);
                                 let reason = ConnectionStateReason::from(args.reason);
-                                debug!("Active connection state changed to: {new_state} (reason: {reason})");
+                                trace!("Active connection state changed to: {new_state} (reason: {reason})");
 
                                 match new_state {
                                     ActiveConnectionState::Activated => {
-                                        debug!("Connection activation successful");
+                                        trace!("Connection activation successful");
                                         return Ok(());
                                     }
                                     ActiveConnectionState::Deactivated => {
@@ -180,10 +180,10 @@ pub(crate) async fn wait_for_device_disconnect(
 ) -> Result<()> {
     // Subscribe to signals FIRST to avoid race condition
     let mut stream = dev.receive_device_state_changed().await?;
-    debug!("Subscribed to device StateChanged signal for disconnect");
+    trace!("Subscribed to device StateChanged signal for disconnect");
 
     let current_state = dev.state().await?;
-    debug!("Current device state for disconnect: {current_state}");
+    trace!("Current device state for disconnect: {current_state}");
 
     if current_state == device_state::DISCONNECTED || current_state == device_state::UNAVAILABLE {
         debug!("Device already disconnected");
@@ -221,12 +221,12 @@ pub(crate) async fn wait_for_device_disconnect(
                         match signal.args() {
                             Ok(args) => {
                                 let new_state = args.new_state;
-                                debug!("Device state during disconnect: {new_state}");
+                                trace!("Device state during disconnect: {new_state}");
 
                                 if new_state == device_state::DISCONNECTED
                                     || new_state == device_state::UNAVAILABLE
                                 {
-                                    debug!("Device reached disconnected state");
+                                    trace!("Device reached disconnected state");
                                     return Ok(());
                                 }
                             }
@@ -248,10 +248,10 @@ pub(crate) async fn wait_for_device_disconnect(
 pub(crate) async fn wait_for_wifi_device_ready(dev: &NMDeviceProxy<'_>) -> Result<()> {
     // Subscribe to signals FIRST to avoid race condition
     let mut stream = dev.receive_device_state_changed().await?;
-    debug!("Subscribed to device StateChanged signal for ready check");
+    trace!("Subscribed to device StateChanged signal for ready check");
 
     let current_state = dev.state().await?;
-    debug!("Current device state for ready check: {current_state}");
+    trace!("Current device state for ready check: {current_state}");
 
     if current_state == device_state::DISCONNECTED || current_state == device_state::ACTIVATED {
         debug!("Device already ready");
@@ -287,12 +287,12 @@ pub(crate) async fn wait_for_wifi_device_ready(dev: &NMDeviceProxy<'_>) -> Resul
                         match signal.args() {
                             Ok(args) => {
                                 let new_state = args.new_state;
-                                debug!("Device state during ready wait: {new_state}");
+                                trace!("Device state during ready wait: {new_state}");
 
                                 if new_state == device_state::DISCONNECTED
                                     || new_state == device_state::ACTIVATED
                                 {
-                                    debug!("Device is now ready");
+                                    trace!("Device is now ready");
                                     return Ok(());
                                 }
                             }

--- a/nmrs/src/core/vpn.rs
+++ b/nmrs/src/core/vpn.rs
@@ -6,7 +6,7 @@
 //!   strongSwan, PPTP, L2TP, and any other installed plugin.
 #![allow(deprecated)]
 
-use log::{debug, info, warn};
+use log::{debug, info, trace, warn};
 use std::collections::HashMap;
 use zbus::Connection;
 use zvariant::OwnedObjectPath;
@@ -641,11 +641,11 @@ pub(crate) async fn connect_vpn(
     let specific_object = OwnedObjectPath::default();
 
     let active_conn = if let Some(saved_path) = saved {
-        debug!("Activating existent VPN connection");
+        trace!("Activating existent VPN connection");
         nm.activate_connection(saved_path, vpn_device_path.clone(), specific_object.clone())
             .await?
     } else {
-        debug!("Creating new VPN connection");
+        trace!("Creating new VPN connection");
         let opts = ConnectionOptions {
             autoconnect: false,
             autoconnect_priority: None,
@@ -666,12 +666,12 @@ pub(crate) async fn connect_vpn(
 
         let settings_api = settings_proxy(conn).await?;
 
-        debug!("Adding connection via Settings API");
+        trace!("Adding connection via Settings API");
         let add_reply = settings_api
             .call_method("AddConnection", &(settings,))
             .await?;
         let conn_path: OwnedObjectPath = add_reply.body().deserialize()?;
-        debug!("Connection added, activating VPN connection");
+        trace!("Connection added, activating VPN connection");
 
         nm.activate_connection(conn_path, vpn_device_path, specific_object)
             .await?
@@ -679,14 +679,14 @@ pub(crate) async fn connect_vpn(
 
     let timeout = timeout_config.map(|c| c.connection_timeout);
     wait_for_connection_activation(conn, &active_conn, timeout).await?;
-    debug!("Connection reached Activated state, waiting briefly...");
+    trace!("Connection reached Activated state, waiting briefly...");
 
     match NMActiveConnectionProxy::builder(conn).path(active_conn.clone()) {
         Ok(builder) => match builder.build().await {
             Ok(active_conn_check) => {
                 let final_state = active_conn_check.state().await?;
                 let state = crate::api::models::ActiveConnectionState::from(final_state);
-                debug!("Connection state after delay: {:?}", state);
+                trace!("Connection state after delay: {:?}", state);
 
                 match state {
                     crate::api::models::ActiveConnectionState::Activated => {
@@ -785,7 +785,7 @@ pub(crate) async fn disconnect_vpn(conn: &Connection, name: &str) -> Result<()> 
         let is_vpn = detect_vpn_kind(&settings_map).is_some();
 
         if id_match && is_vpn {
-            debug!("Found active VPN connection, deactivating: {name}");
+            trace!("Found active VPN connection, deactivating: {name}");
             nm.deactivate_connection(ac_path.clone()).await?;
             info!("Successfully disconnected VPN: {name}");
             return Ok(());
@@ -803,7 +803,7 @@ pub(crate) async fn forget_vpn(conn: &Connection, name: &str) -> Result<()> {
     debug!("Starting forget operation for VPN: {name}");
 
     match disconnect_vpn(conn, name).await {
-        Ok(_) => debug!("VPN disconnected before deletion"),
+        Ok(_) => trace!("VPN disconnected before deletion"),
         Err(e) => warn!(
             "Failed to disconnect VPN before deletion (may already be disconnected): {}",
             e
@@ -846,7 +846,7 @@ pub(crate) async fn forget_vpn(conn: &Connection, name: &str) -> Result<()> {
         let vpn_kind = detect_vpn_kind(&settings_map);
 
         if id_ok && vpn_kind.is_some() {
-            debug!("Found VPN connection, deleting: {name}");
+            trace!("Found VPN connection, deleting: {name}");
             cproxy.call_method("Delete", &()).await.map_err(|e| {
                 ConnectionError::DbusOperation {
                     context: format!("failed to delete VPN connection '{}'", name),

--- a/nmrs/src/core/wifi_device.rs
+++ b/nmrs/src/core/wifi_device.rs
@@ -6,7 +6,7 @@
 //! `Device.Disconnect()` — the kernel hands the radio back to NM but no
 //! connection will be re-activated until autoconnect is re-enabled.
 
-use log::{debug, warn};
+use log::{trace, warn};
 use zbus::Connection;
 
 use crate::Result;
@@ -120,7 +120,7 @@ pub(crate) async fn set_wifi_enabled_for_interface(
         });
     }
 
-    debug!("setting Autoconnect={} for {}", enabled, interface);
+    trace!("setting Autoconnect={} for {}", enabled, interface);
     if let Err(e) = dev.set_autoconnect(enabled).await {
         warn!("failed to set autoconnect on {}: {}", interface, e);
         return Err(ConnectionError::DbusOperation {

--- a/nmrs/src/monitoring/device.rs
+++ b/nmrs/src/monitoring/device.rs
@@ -5,7 +5,7 @@
 //! to poll. This enables live UI updates for both wired and wireless devices.
 
 use futures::stream::{Stream, StreamExt};
-use log::debug;
+use log::{debug, trace};
 use std::pin::Pin;
 use tokio::select;
 use tokio::sync::watch;
@@ -55,7 +55,7 @@ where
     streams.push(Box::pin(device_removed_stream.map(|_| ())));
     streams.push(Box::pin(state_changed_stream.map(|_| ())));
 
-    debug!("Subscribed to NetworkManager device signals");
+    trace!("Subscribed to NetworkManager device signals");
 
     // Also subscribe to individual device state changes for existing devices
     let devices = nm.get_devices().await?;
@@ -67,7 +67,7 @@ where
             && let Ok(state_stream) = dev.receive_device_state_changed().await
         {
             streams.push(Box::pin(state_stream.map(|_| ())));
-            debug!("Subscribed to state change signals on device: {dev_path}");
+            trace!("Subscribed to state change signals on device: {dev_path}");
         }
     }
 

--- a/nmrs/src/monitoring/events.rs
+++ b/nmrs/src/monitoring/events.rs
@@ -4,7 +4,7 @@ use std::pin::Pin;
 
 use futures::channel::mpsc;
 use futures::stream::{Stream, StreamExt};
-use log::{debug, warn};
+use log::{trace, warn};
 use zbus::Connection;
 use zvariant::OwnedObjectPath;
 
@@ -86,7 +86,7 @@ async fn run_network_events(
                 }
                 match access_point_strength_stream(&conn, path.clone()).await {
                     Ok(stream) => merged.push(stream),
-                    Err(err) => debug!("failed to monitor access point {path}: {err}"),
+                    Err(err) => trace!("failed to monitor access point {path}: {err}"),
                 }
             }
             InternalEvent::AccessPointRemoved => {
@@ -101,7 +101,7 @@ async fn run_network_events(
                 }
                 match device_state_stream(&conn, path.clone()).await {
                     Ok(stream) => merged.push(stream),
-                    Err(err) => debug!("failed to monitor device {path}: {err}"),
+                    Err(err) => trace!("failed to monitor device {path}: {err}"),
                 }
                 match wireless_device_streams(&conn, path.clone()).await {
                     Ok(streams) => {
@@ -109,7 +109,7 @@ async fn run_network_events(
                             merged.push(stream);
                         }
                     }
-                    Err(err) => debug!("failed to monitor wireless device {path}: {err}"),
+                    Err(err) => trace!("failed to monitor wireless device {path}: {err}"),
                 }
             }
             InternalEvent::DeviceRemoved => {
@@ -195,7 +195,7 @@ async fn device_state_streams<'a>(
     for path in nm.get_devices().await? {
         match device_state_stream(conn, path.clone()).await {
             Ok(stream) => streams.push(stream),
-            Err(err) => debug!("failed to monitor device {path}: {err}"),
+            Err(err) => trace!("failed to monitor device {path}: {err}"),
         }
     }
 
@@ -242,7 +242,7 @@ async fn access_point_streams<'a>(
     for device_path in nm.get_devices().await? {
         match wireless_device_streams(conn, device_path.clone()).await {
             Ok(device_streams) => streams.extend(device_streams),
-            Err(err) => debug!("failed to monitor wireless device {device_path}: {err}"),
+            Err(err) => trace!("failed to monitor wireless device {device_path}: {err}"),
         }
     }
 
@@ -289,11 +289,11 @@ async fn wireless_device_streams<'a>(
             for access_point in access_points {
                 match access_point_strength_stream(conn, access_point.clone()).await {
                     Ok(stream) => streams.push(stream),
-                    Err(err) => debug!("failed to monitor access point {access_point}: {err}"),
+                    Err(err) => trace!("failed to monitor access point {access_point}: {err}"),
                 }
             }
         }
-        Err(err) => debug!("failed to list access points on {device_path}: {err}"),
+        Err(err) => trace!("failed to list access points on {device_path}: {err}"),
     }
 
     Ok(streams)

--- a/nmrs/src/monitoring/info.rs
+++ b/nmrs/src/monitoring/info.rs
@@ -3,7 +3,7 @@
 //! Provides functions to retrieve detailed information about WiFi networks,
 //! including security capabilities, signal strength, and connection details.
 
-use log::debug;
+use log::trace;
 use zbus::Connection;
 
 use crate::Result;
@@ -84,21 +84,21 @@ pub(crate) async fn show_details(conn: &Connection, net: &Network) -> Result<Net
             let freq = match ap.frequency().await {
                 Ok(f) => Some(f),
                 Err(e) => {
-                    debug!("Failed to get frequency for AP: {}", e);
+                    trace!("Failed to get frequency for AP: {}", e);
                     None
                 }
             };
             let max_br = match ap.max_bitrate().await {
                 Ok(br) => Some(br),
                 Err(e) => {
-                    debug!("Failed to get max bitrate for AP: {}", e);
+                    trace!("Failed to get max bitrate for AP: {}", e);
                     None
                 }
             };
             let mode_raw = match ap.mode().await {
                 Ok(m) => Some(m),
                 Err(e) => {
-                    debug!("Failed to get mode for AP: {}", e);
+                    trace!("Failed to get mode for AP: {}", e);
                     None
                 }
             };

--- a/nmrs/src/monitoring/network.rs
+++ b/nmrs/src/monitoring/network.rs
@@ -5,7 +5,7 @@
 //! enables live UI updates.
 
 use futures::stream::{Stream, StreamExt};
-use log::{debug, warn};
+use log::{debug, trace, warn};
 use std::collections::HashSet;
 use std::pin::Pin;
 use tokio::select;
@@ -117,14 +117,14 @@ where
             Err(err) => debug!("Failed to list access points on device {dev_path}: {err}"),
         }
 
-        debug!("Subscribed to network change signals on device: {dev_path}");
+        trace!("Subscribed to network change signals on device: {dev_path}");
     }
 
     let device_added_stream = nm.receive_device_added().await?;
     streams.push(Box::pin(device_added_stream.map(|signal| {
         signal.args().map_or_else(
             |err| {
-                debug!("Failed to parse DeviceAdded signal: {err}");
+                trace!("Failed to parse DeviceAdded signal: {err}");
                 NetworkChange::SignalStrengthChanged
             },
             |args| NetworkChange::DeviceAdded(args.device().clone()),
@@ -177,7 +177,7 @@ where
                         )
                         .await
                         {
-                            debug!("Hotplugged device {dev_path} is not Wi-Fi or failed: {err}");
+                            trace!("Hotplugged device {dev_path} is not Wi-Fi or failed: {err}");
                         } else {
                             debug!("Subscribed to hotplugged Wi-Fi device: {dev_path}");
                             callback();
@@ -218,7 +218,7 @@ async fn subscribe_wifi_device(
     merged.push(Box::pin(added_stream.map(|signal| {
         signal.args().map_or_else(
             |err| {
-                debug!("Failed to parse AccessPointAdded signal: {err}");
+                trace!("Failed to parse AccessPointAdded signal: {err}");
                 NetworkChange::SignalStrengthChanged
             },
             |args| NetworkChange::Added(args.path().clone()),
@@ -227,7 +227,7 @@ async fn subscribe_wifi_device(
     merged.push(Box::pin(removed_stream.map(|signal| {
         signal.args().map_or_else(
             |err| {
-                debug!("Failed to parse AccessPointRemoved signal: {err}");
+                trace!("Failed to parse AccessPointRemoved signal: {err}");
                 NetworkChange::SignalStrengthChanged
             },
             |args| NetworkChange::Removed(args.path().clone()),
@@ -241,7 +241,7 @@ async fn subscribe_wifi_device(
             }
             match access_point_strength_stream(conn, ap_path.clone()).await {
                 Ok(stream) => merged.push(stream),
-                Err(err) => debug!(
+                Err(err) => trace!(
                     "Failed to monitor signal strength for access point {}: {}",
                     ap_path, err
                 ),
@@ -262,7 +262,7 @@ async fn access_point_strength_stream(
         .await?;
 
     let stream = ap.receive_strength_changed().await.skip(1).map(move |_| {
-        debug!("Access point signal strength changed: {ap_path}");
+        trace!("Access point signal strength changed: {ap_path}");
         NetworkChange::SignalStrengthChanged
     });
 

--- a/nmrs/src/monitoring/settings.rs
+++ b/nmrs/src/monitoring/settings.rs
@@ -4,7 +4,7 @@ use std::pin::Pin;
 
 use futures::channel::mpsc;
 use futures::stream::{Stream, StreamExt};
-use log::{debug, warn};
+use log::{trace, warn};
 use zbus::Connection;
 use zvariant::OwnedObjectPath;
 
@@ -126,7 +126,7 @@ async fn connection_settings_streams(
         .await?
         .map(move |_| SettingsSignal::Removed(path.clone()));
 
-    debug!("subscribed to settings connection signals");
+    trace!("subscribed to settings connection signals");
     let streams: Vec<SettingsSignalStream> = vec![Box::pin(updated), Box::pin(removed)];
     Ok(streams)
 }

--- a/nmrs/src/util/utils.rs
+++ b/nmrs/src/util/utils.rs
@@ -3,7 +3,7 @@
 //! Provides helpers for converting between Wi-Fi data representations:
 //! frequency to channel, signal strength to visual bars, SSID bytes to strings.
 
-use log::{debug, warn};
+use log::{trace, warn};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::str;
@@ -246,7 +246,7 @@ pub(crate) async fn extract_connection_state_reason(
         Ok(builder) => match builder.build().await {
             Ok(ac) => match ac.state().await {
                 Ok(state) => {
-                    debug!(
+                    trace!(
                         "Active connection state: {}, but reason not available as property",
                         state
                     );


### PR DESCRIPTION
**Summary:**
This PR refactors the logging levels to reduce console noise during normal runtime. Around 80 logging statements across 16 files (core, agent, and monitoring modules) have been adjusted from debug! down to trace!.

The changes specifically target high-frequency hardware events and expected asynchronous lifecycle fallbacks, while leaving core business logic and critical state transitions untouched on the default levels.

Closes #189 