### PR TITLE
test/docs: document and expand test coverage for connection priority and retries

### DIFF
--- a/docs/src/advanced/connection-options.md
+++ b/docs/src/advanced/connection-options.md
@@ -54,16 +54,16 @@ When multiple saved connections are available (e.g., you're in range of both "Ho
 | Priority | Use Case |
 |----------|----------|
 | 0 (default) | Normal connections |
-| 1–10 | Preferred connections |
-| -1 to -10 | Fallback connections |
+| Positive (`> 0`) | Preferred connections (higher values take precedence, e.g., `100` over `10`) |
+| Negative (`< 0`) | Fallback connections (lower values are tried last, e.g., `-50` after `-10`) |
 
 ## How Retries Work
 
 `autoconnect_retries` limits how many times NetworkManager will try to auto-connect a failing connection:
 
-- `None` (default) — unlimited retries
-- `Some(0)` — never auto-retry
-- `Some(3)` — try up to 3 times, then stop
+- `None` (default) — Uses NetworkManager's global default configuration (4 attempts).
+- `Some(0)` — Explicitly forces **unlimited** retry attempts.
+- `Some(n)` — Stops attempting to auto-connect after exactly `n` failed retries.
 
 This is useful for connections that might intermittently fail (e.g., a network at the edge of range).
 

--- a/docs/src/guide/wifi.md
+++ b/docs/src/guide/wifi.md
@@ -149,8 +149,8 @@ for net in networks {
 use nmrs::ConnectionOptions;
 
 let opts = ConnectionOptions::new(true)   // autoconnect
-    .with_priority(10)                    // higher = preferred
-    .with_retries(3);                     // 0 means never retry, None = unlimited
+    .with_priority(10)                    // higher = preferred, supports negative fallback values
+    .with_retries(3);                     // Some(n) = retry n times, Some(0) = unlimited, None = default (usually 4 attempts)
 ```
 
 This struct intentionally only covers the connection-management knobs

--- a/nmrs/src/api/builders/wifi.rs
+++ b/nmrs/src/api/builders/wifi.rs
@@ -435,19 +435,19 @@ mod tests {
     }
 
     #[test]
-    fn connection_with_max_priority_values() {
+    fn connection_with_max_valid_boundaries() {
         let opts = ConnectionOptions {
             autoconnect: true,
-            autoconnect_priority: Some(i32::MAX),
-            autoconnect_retries: Some(i32::MAX),
+            autoconnect_priority: Some(999),     // NM max priority
+            autoconnect_retries: Some(i32::MAX), // NM max retries
         };
 
-        let conn = build_wifi_connection("max_priority_net", &WifiSecurity::Open, &opts);
+        let conn = build_wifi_connection("max_boundaries_net", &WifiSecurity::Open, &opts);
         let connection_section = conn.get("connection").unwrap();
 
         assert_eq!(
             connection_section.get("autoconnect-priority"),
-            Some(&Value::from(i32::MAX))
+            Some(&Value::from(999i32))
         );
         assert_eq!(
             connection_section.get("autoconnect-retries"),
@@ -456,37 +456,20 @@ mod tests {
     }
 
     #[test]
-    fn connection_with_min_priority_and_retries() {
+    fn connection_with_min_valid_boundaries() {
         let opts = ConnectionOptions {
             autoconnect: true,
-            autoconnect_priority: Some(i32::MIN),
-            autoconnect_retries: Some(i32::MIN),
+            autoconnect_priority: Some(-999), // NM min priority
+            autoconnect_retries: Some(-1),    // NM default retries
         };
 
-        let conn = build_wifi_connection("min_values_net", &WifiSecurity::Open, &opts);
+        let conn = build_wifi_connection("min_boundaries_net", &WifiSecurity::Open, &opts);
         let connection_section = conn.get("connection").unwrap();
 
         assert_eq!(
             connection_section.get("autoconnect-priority"),
-            Some(&Value::from(i32::MIN))
+            Some(&Value::from(-999i32))
         );
-        assert_eq!(
-            connection_section.get("autoconnect-retries"),
-            Some(&Value::from(i32::MIN))
-        );
-    }
-
-    #[test]
-    fn connection_with_explicit_negative_retries() {
-        let opts = ConnectionOptions {
-            autoconnect: true,
-            autoconnect_priority: None,
-            autoconnect_retries: Some(-1), // NM explicitly treats -1 as "use global default"
-        };
-
-        let conn = build_wifi_connection("default_retries_net", &WifiSecurity::Open, &opts);
-        let connection_section = conn.get("connection").unwrap();
-
         assert_eq!(
             connection_section.get("autoconnect-retries"),
             Some(&Value::from(-1i32))

--- a/nmrs/src/api/builders/wifi.rs
+++ b/nmrs/src/api/builders/wifi.rs
@@ -412,4 +412,84 @@ mod tests {
         let ssid = wireless.get("ssid").unwrap();
         assert_eq!(ssid, &Value::from("Café-Wïfì_123".as_bytes().to_vec()));
     }
+
+    #[test]
+    fn connection_with_negative_priority_and_zero_retries() {
+        let opts = ConnectionOptions {
+            autoconnect: true,
+            autoconnect_priority: Some(-5),
+            autoconnect_retries: Some(0), // 0 means try indefinitely in NM
+        };
+
+        let conn = build_wifi_connection("fallback_net", &WifiSecurity::Open, &opts);
+        let connection_section = conn.get("connection").unwrap();
+
+        assert_eq!(
+            connection_section.get("autoconnect-priority"),
+            Some(&Value::from(-5i32))
+        );
+        assert_eq!(
+            connection_section.get("autoconnect-retries"),
+            Some(&Value::from(0i32))
+        );
+    }
+
+    #[test]
+    fn connection_with_max_priority_values() {
+        let opts = ConnectionOptions {
+            autoconnect: true,
+            autoconnect_priority: Some(i32::MAX),
+            autoconnect_retries: Some(i32::MAX),
+        };
+
+        let conn = build_wifi_connection("max_priority_net", &WifiSecurity::Open, &opts);
+        let connection_section = conn.get("connection").unwrap();
+
+        assert_eq!(
+            connection_section.get("autoconnect-priority"),
+            Some(&Value::from(i32::MAX))
+        );
+        assert_eq!(
+            connection_section.get("autoconnect-retries"),
+            Some(&Value::from(i32::MAX))
+        );
+    }
+
+    #[test]
+    fn connection_with_min_priority_and_retries() {
+        let opts = ConnectionOptions {
+            autoconnect: true,
+            autoconnect_priority: Some(i32::MIN),
+            autoconnect_retries: Some(i32::MIN),
+        };
+
+        let conn = build_wifi_connection("min_values_net", &WifiSecurity::Open, &opts);
+        let connection_section = conn.get("connection").unwrap();
+
+        assert_eq!(
+            connection_section.get("autoconnect-priority"),
+            Some(&Value::from(i32::MIN))
+        );
+        assert_eq!(
+            connection_section.get("autoconnect-retries"),
+            Some(&Value::from(i32::MIN))
+        );
+    }
+
+    #[test]
+    fn connection_with_explicit_negative_retries() {
+        let opts = ConnectionOptions {
+            autoconnect: true,
+            autoconnect_priority: None,
+            autoconnect_retries: Some(-1), // NM explicitly treats -1 as "use global default"
+        };
+
+        let conn = build_wifi_connection("default_retries_net", &WifiSecurity::Open, &opts);
+        let connection_section = conn.get("connection").unwrap();
+
+        assert_eq!(
+            connection_section.get("autoconnect-retries"),
+            Some(&Value::from(-1i32))
+        );
+    }
 }

--- a/nmrs/src/api/models/config.rs
+++ b/nmrs/src/api/models/config.rs
@@ -159,7 +159,7 @@ impl Default for ConnectionOptions {
     /// Defaults:
     /// - `autoconnect`: `true`
     /// - `autoconnect_priority`: `None` (uses NetworkManager's default of 0)
-    /// - `autoconnect_retries`: `None` (unlimited retries)
+    /// - `autoconnect_retries`: `None` (uses NetworkManager's global default configuration of 4 retries)
     fn default() -> Self {
         Self {
             autoconnect: true,

--- a/nmrs/src/api/models/config.rs
+++ b/nmrs/src/api/models/config.rs
@@ -126,7 +126,6 @@ impl TimeoutConfig {
 /// // Manual connection only
 /// let opts_manual = ConnectionOptions::new(false);
 /// ```
-
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct ConnectionOptions {

--- a/nmrs/src/api/models/config.rs
+++ b/nmrs/src/api/models/config.rs
@@ -126,14 +126,31 @@ impl TimeoutConfig {
 /// // Manual connection only
 /// let opts_manual = ConnectionOptions::new(false);
 /// ```
+
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct ConnectionOptions {
-    /// Whether to automatically connect when available
+    /// Whether to automatically connect when available.
     pub autoconnect: bool,
-    /// Priority for auto-connection (higher = more preferred)
+
+    /// Priority for auto-connection (higher = more preferred).
+    ///
+    /// NetworkManager uses this value to determine which network to prefer when
+    /// multiple configured networks are available at the same time.
+    ///
+    /// - **Higher values** have higher priority.
+    /// - **Default value** is `0` (if set to `None`).
+    /// - **Negative values** are allowed and indicate lower priority than default.
     pub autoconnect_priority: Option<i32>,
-    /// Maximum number of auto-connect retry attempts
+
+    /// Maximum number of auto-connect retry attempts.
+    ///
+    /// Configures how many times NetworkManager will attempt to automatically
+    /// reconnect if activation fails.
+    ///
+    /// - `Some(0)`: try indefinitely.
+    /// - `Some(n)`: retry up to `n` times.
+    /// - `None`: uses NetworkManager's global default configuration (4 attempts).
     pub autoconnect_retries: Option<i32>,
 }
 


### PR DESCRIPTION
This PR updates the documentation and adds additional tests for `ConnectionOptions`, particularly for `autoconnect_priority` and `autoconnect_retries`.

Although the implementation was already in place, the documentation needed clarification to better match NetworkManager's specifications. The test suite has also been expanded to cover boundary values, providing better confidence that the mapping behaves as expected.


Closes #218 