### PR TITLE
tests(#483): display tests for ConnectivityStatus

### DIFF
--- a/nmrs/src/api/models/connectivity.rs
+++ b/nmrs/src/api/models/connectivity.rs
@@ -125,5 +125,15 @@ mod tests {
         assert!(!ConnectivityState::Portal.is_usable_for_internet());
         assert!(!ConnectivityState::Limited.is_usable_for_internet());
         assert!(!ConnectivityState::Unknown.is_usable_for_internet());
+}
+
+    #[test]
+    fn display_test() {
+        assert_eq!(format!("{}", ConnectivityState::Unknown), "unknown");
+        assert_eq!(format!("{}", ConnectivityState::None), "none");
+        assert_eq!(format!("{}", ConnectivityState::Portal), "portal");
+        assert_eq!(format!("{}", ConnectivityState::Limited), "limited");
+        assert_eq!(format!("{}", ConnectivityState::Full), "full");
     }
+    
 }

--- a/nmrs/src/api/models/connectivity.rs
+++ b/nmrs/src/api/models/connectivity.rs
@@ -125,7 +125,7 @@ mod tests {
         assert!(!ConnectivityState::Portal.is_usable_for_internet());
         assert!(!ConnectivityState::Limited.is_usable_for_internet());
         assert!(!ConnectivityState::Unknown.is_usable_for_internet());
-}
+    }
 
     #[test]
     fn display_test() {
@@ -135,5 +135,4 @@ mod tests {
         assert_eq!(format!("{}", ConnectivityState::Limited), "limited");
         assert_eq!(format!("{}", ConnectivityState::Full), "full");
     }
-    
 }


### PR DESCRIPTION
This is in response to issue 483, providing unit tests for impl Display in ConnectivityStatus. 

Closes #483