### PR TITLE
fix(#485): only output visible SSIDs

### DIFF
--- a/docs/src/api/models.md
+++ b/docs/src/api/models.md
@@ -186,7 +186,7 @@ let saved_vpns = snapshot.saved_vpn_map();
 let applet = snapshot.applet_summary();
 ```
 
-`wifi_groups()` groups access points by `(interface, ssid)`, keeps every BSSID,
+`wifi_groups()` groups visible access points by `(interface, ssid)`, keeps every BSSID,
 marks known networks from matching saved profiles, and marks the active group
 from typed active Wi-Fi connections.
 

--- a/nmrs/src/api/models/snapshot.rs
+++ b/nmrs/src/api/models/snapshot.rs
@@ -74,11 +74,11 @@ impl NetworkSnapshot {
     pub fn wifi_groups(&self) -> Vec<WifiNetworkGroup> {
         let mut grouped: HashMap<(String, String), Vec<AccessPoint>> = HashMap::new();
         for ap in &self.access_points {
-            if &ap.ssid != "" {
-            grouped
-                .entry((ap.interface.clone(), ap.ssid.clone()))
-                .or_default()
-                .push(ap.clone());
+            if !ap.ssid.is_empty() {
+                grouped
+                    .entry((ap.interface.clone(), ap.ssid.clone()))
+                    .or_default()
+                    .push(ap.clone());
             }
         }
 

--- a/nmrs/src/api/models/snapshot.rs
+++ b/nmrs/src/api/models/snapshot.rs
@@ -74,10 +74,12 @@ impl NetworkSnapshot {
     pub fn wifi_groups(&self) -> Vec<WifiNetworkGroup> {
         let mut grouped: HashMap<(String, String), Vec<AccessPoint>> = HashMap::new();
         for ap in &self.access_points {
+            if &ap.ssid != "" {
             grouped
-                .entry((ap.interface.clone(), ap.ssid.clone()))
+                .entry((ap.interface.clone(), (ap.ssid.clone())))
                 .or_default()
                 .push(ap.clone());
+            }
         }
 
         let mut groups = grouped
@@ -667,5 +669,20 @@ mod tests {
         assert!(!vpns["wg-vpn"].active);
         assert_eq!(vpns["active-vpn"].kind, Some(VpnKind::Plugin));
         assert_eq!(vpns["wg-vpn"].kind, Some(VpnKind::WireGuard));
+    }
+
+    #[test]
+    fn hidden_networks_not_shown() {
+        let snapshot = snapshot(
+            vec![
+                ap("wlan0", "", "AA:AA:AA:AA:AA:01", 70),
+                ap("wlan1", "Cafe", "BB:BB:BB:BB:BB:01", 90),
+            ],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        let groups = snapshot.wifi_groups();
+        assert_eq!(groups.len(), 1);
     }
 }

--- a/nmrs/src/api/models/snapshot.rs
+++ b/nmrs/src/api/models/snapshot.rs
@@ -76,7 +76,7 @@ impl NetworkSnapshot {
         for ap in &self.access_points {
             if &ap.ssid != "" {
             grouped
-                .entry((ap.interface.clone(), (ap.ssid.clone())))
+                .entry((ap.interface.clone(), ap.ssid.clone()))
                 .or_default()
                 .push(ap.clone());
             }


### PR DESCRIPTION
Connected to Issue #485 , based on documentation in wifi-per-device.md the expected output of NetworkSnapshot::wifi_groups() is only visible networks. The function was updated to only output the visible networks and is confirmed with a new test. In addition /api/models.md was updated to be consistent with this new functionality. 

If any additional changes are needed I'd be happy to work on providing them here. 

Closes #485