### PR TITLE
refactor(#495): method to discover hidden networks (opt-in)

### DIFF
--- a/nmrs/src/api/models/access_point.rs
+++ b/nmrs/src/api/models/access_point.rs
@@ -50,6 +50,12 @@ pub struct AccessPoint {
     pub device_state: DeviceState,
 }
 
+impl AccessPoint {
+    pub fn is_hidden(&self) -> bool {
+        self.ssid_bytes.is_empty()
+    }
+}
+
 /// Wi-Fi access point operating mode.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]

--- a/nmrs/src/api/models/access_point.rs
+++ b/nmrs/src/api/models/access_point.rs
@@ -26,7 +26,7 @@ pub struct AccessPoint {
     pub device_path: OwnedObjectPath,
     /// Interface name of the device (e.g. `"wlan0"`).
     pub interface: String,
-    /// SSID decoded as UTF-8, or `"<hidden>"` for hidden networks.
+    /// SSID decoded as UTF-8, or `"<Hidden Network>"` for hidden networks.
     pub ssid: String,
     /// Raw SSID bytes for non-UTF-8 SSIDs.
     pub ssid_bytes: Vec<u8>,
@@ -51,6 +51,8 @@ pub struct AccessPoint {
 }
 
 impl AccessPoint {
+    /// Returns `true` when NetworkManager did not report an SSID for this AP.
+    #[must_use]
     pub fn is_hidden(&self) -> bool {
         self.ssid_bytes.is_empty()
     }

--- a/nmrs/src/api/models/snapshot.rs
+++ b/nmrs/src/api/models/snapshot.rs
@@ -74,12 +74,13 @@ impl NetworkSnapshot {
     pub fn wifi_groups(&self) -> Vec<WifiNetworkGroup> {
         let mut grouped: HashMap<(String, String), Vec<AccessPoint>> = HashMap::new();
         for ap in &self.access_points {
-            if !ap.ssid.is_empty() {
-                grouped
-                    .entry((ap.interface.clone(), ap.ssid.clone()))
-                    .or_default()
-                    .push(ap.clone());
+            if ap.is_hidden() {
+                continue;
             }
+            grouped
+                .entry((ap.interface.clone(), ap.ssid.clone()))
+                .or_default()
+                .push(ap.clone());
         }
 
         let mut groups = grouped
@@ -185,6 +186,15 @@ impl NetworkSnapshot {
             connectivity: self.connectivity.clone(),
             airplane_mode: self.airplane_mode,
         }
+    }
+
+    #[must_use]
+    pub fn hidden_access_points(&self) -> Vec<AccessPoint> {
+        self.access_points
+            .clone()
+            .into_iter()
+            .filter(|x| x.is_hidden())
+            .collect()
     }
 }
 
@@ -684,5 +694,23 @@ mod tests {
         );
         let groups = snapshot.wifi_groups();
         assert_eq!(groups.len(), 1);
+    }
+
+    #[test]
+    fn hidden_networks_available() {
+        let snapshot = snapshot(
+            vec![
+                ap("wlan0", "", "AA:AA:AA:AA:AA:01", 70),
+                ap("wlan1", "Cafe", "BB:BB:BB:BB:BB:01", 90),
+            ],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        let empty_groups: Vec<AccessPoint> = snapshot.hidden_access_points();
+        let groups = snapshot.wifi_groups();
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].ssid, "Cafe");
+        assert_eq!(empty_groups.len(), 1);
     }
 }

--- a/nmrs/src/api/models/snapshot.rs
+++ b/nmrs/src/api/models/snapshot.rs
@@ -188,12 +188,13 @@ impl NetworkSnapshot {
         }
     }
 
+    /// Returns individually reported APs whose raw SSID is empty.
     #[must_use]
     pub fn hidden_access_points(&self) -> Vec<AccessPoint> {
         self.access_points
-            .clone()
-            .into_iter()
-            .filter(|x| x.is_hidden())
+            .iter()
+            .filter(|access_point| access_point.is_hidden())
+            .cloned()
             .collect()
     }
 }
@@ -425,6 +426,12 @@ mod tests {
             is_active: false,
             device_state: DeviceState::Disconnected,
         }
+    }
+
+    fn hidden_ap(interface: &str, bssid: &str, strength: u8) -> AccessPoint {
+        let mut access_point = ap(interface, "<Hidden Network>", bssid, strength);
+        access_point.ssid_bytes.clear();
+        access_point
     }
 
     fn saved_wifi(
@@ -685,7 +692,7 @@ mod tests {
     fn hidden_networks_not_shown() {
         let snapshot = snapshot(
             vec![
-                ap("wlan0", "", "AA:AA:AA:AA:AA:01", 70),
+                hidden_ap("wlan0", "AA:AA:AA:AA:AA:01", 70),
                 ap("wlan1", "Cafe", "BB:BB:BB:BB:BB:01", 90),
             ],
             Vec::new(),
@@ -700,17 +707,19 @@ mod tests {
     fn hidden_networks_available() {
         let snapshot = snapshot(
             vec![
-                ap("wlan0", "", "AA:AA:AA:AA:AA:01", 70),
+                hidden_ap("wlan0", "AA:AA:AA:AA:AA:01", 70),
                 ap("wlan1", "Cafe", "BB:BB:BB:BB:BB:01", 90),
             ],
             Vec::new(),
             Vec::new(),
             Vec::new(),
         );
-        let empty_groups: Vec<AccessPoint> = snapshot.hidden_access_points();
+        let hidden_access_points = snapshot.hidden_access_points();
         let groups = snapshot.wifi_groups();
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].ssid, "Cafe");
-        assert_eq!(empty_groups.len(), 1);
+        assert_eq!(hidden_access_points.len(), 1);
+        assert!(hidden_access_points[0].is_hidden());
+        assert_eq!(hidden_access_points[0].ssid, "<Hidden Network>");
     }
 }


### PR DESCRIPTION
A minor refactor to address issue #495. I believe this will make hidden ap's available, and should now hide them by default. If we wanted to also handle the parsing of the hidden ap's names I can work on that next, however I believe that is out of the scope of this issue. 

I addressed some of the examples to show that all_wifi_groups are available; however I did not add them to many examples that did not use them directly.

Closes #495