### PR TITLE
refactor: remove `current_bluetooth_info`

### DIFF
--- a/nmrs/src/monitoring/bluetooth.rs
+++ b/nmrs/src/monitoring/bluetooth.rs
@@ -83,51 +83,6 @@ pub(crate) async fn current_bluetooth_bdaddr(conn: &Connection) -> Option<String
     None
 }
 
-/// Returns detailed information about the current Bluetooth connection.
-///
-/// Similar to `current_bluetooth_bdaddr` but also returns the Bluetooth
-/// capabilities (DUN or PANU) of the connected device.
-///
-/// Returns `Some((bdaddr, capabilities))` if connected, `None` otherwise.
-#[allow(dead_code)]
-pub(crate) async fn current_bluetooth_info(conn: &Connection) -> Option<(String, u32)> {
-    let nm = try_log!(NMProxy::new(conn).await, "Failed to create NM proxy");
-    let devices = try_log!(nm.get_devices().await, "Failed to get devices");
-
-    for dp in devices {
-        let dev_builder = try_log!(
-            NMDeviceProxy::builder(conn).path(dp.clone()),
-            "Failed to create device proxy builder"
-        );
-        let dev = try_log!(dev_builder.build().await, "Failed to build device proxy");
-
-        let dev_type = try_log!(dev.device_type().await, "Failed to get device type");
-        if dev_type != device_type::BLUETOOTH {
-            continue;
-        }
-
-        // Check if device is in an active/connected state
-        let state = try_log!(dev.state().await, "Failed to get device state");
-        // State 100 = Activated (connected)
-        if state != device_state::ACTIVATED {
-            continue;
-        }
-
-        // Get the Bluetooth MAC address and capabilities
-        let bt_builder = try_log!(
-            NMBluetoothProxy::builder(conn).path(dp.clone()),
-            "Failed to create Bluetooth proxy builder"
-        );
-        let bt = try_log!(bt_builder.build().await, "Failed to build Bluetooth proxy");
-
-        if let (Ok(bdaddr), Ok(capabilities)) = (bt.hw_address().await, bt.bt_capabilities().await)
-        {
-            return Some((bdaddr, capabilities));
-        }
-    }
-    None
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Gets rid of current_bluetooth_info, as it is dead code.
Closes #480 
