### PR TITLE
docs(#477): handle MonitorHandle result & demonstrate stop network monitoring

### DIFF
--- a/docs/src/getting-started/quick-start.md
+++ b/docs/src/getting-started/quick-start.md
@@ -185,7 +185,7 @@ Monitor network changes:
 
 ```rust
 use nmrs::NetworkManager;
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> nmrs::Result<()> {

--- a/docs/src/getting-started/quick-start.md
+++ b/docs/src/getting-started/quick-start.md
@@ -185,7 +185,7 @@ Monitor network changes:
 
 ```rust
 use nmrs::NetworkManager;
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 #[tokio::main]
 async fn main() -> nmrs::Result<()> {
@@ -193,13 +193,17 @@ async fn main() -> nmrs::Result<()> {
     let nm_clone = nm.clone();
     
     // Monitor network changes
-    nm.monitor_network_changes(move || {
+    let monitor_handle = nm.monitor_network_changes(move || {
         println!("Networks changed! Scanning...");
         // In a real app, you'd update your UI here
     }).await?;
-    
-    // Keep the program running
-    tokio::signal::ctrl_c().await.ok();
+
+    // Wait a moment for any network changes
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+    // Stop monitoring with a clean shutdown
+    monitor_handle.stop().await?;
+    println!("Monitoring stopped...");
     Ok(())
 }
 ```


### PR DESCRIPTION
Closes #477 
Demonstrates ```monitor_handle.stop().await?``` to shutdown network monitoring with a clean exit.
Doc `quick-start.md`