### PR TITLE
fix: vpn classified as wired

### DIFF
--- a/nmrs/CHANGELOG.md
+++ b/nmrs/CHANGELOG.md
@@ -10,10 +10,14 @@ All notable changes to the `nmrs` crate will be documented in this file.
   passwords and private keys from debug output, and connection tracing no
   longer logs raw settings, without changing public field types. ([#508](https://github.com/freedesktop-rs/nmrs/pull/508))
 - Non-palindromic IPv4 DNS server addresses are no longer rejected by the
-  OpenVPN and WireGuard builders. ([#509](https://github.com/freedesktop-rs/nmrs/pull/519))
+  OpenVPN and WireGuard builders. ([#519](https://github.com/freedesktop-rs/nmrs/pull/519))
 
 ### Fixed
 
+- Classify an active VPN as `ActiveConnection::Vpn` even when NetworkManager
+  parents it on the physical device it tunnels over, so OpenVPN-style tunnels
+  over Ethernet are no longer reported as
+  `ActiveConnection::Wired`. ([#520](https://github.com/freedesktop-rs/nmrs/pull/520))
 - Resolve Bluetooth devices through the BlueZ adapter that owns their address
   instead of assuming the adapter is `hci0`. ([#501](https://github.com/freedesktop-rs/nmrs/pull/501))
 

--- a/nmrs/src/core/active_connection.rs
+++ b/nmrs/src/core/active_connection.rs
@@ -367,10 +367,16 @@ fn active_connection_kind(
     raw_device_type: Option<u32>,
     connection_type: Option<&str>,
 ) -> ActiveConnectionKind {
+    // NetworkManager parents a VPN's active connection on the device it tunnels
+    // over, so an OpenVPN tunnel over Ethernet reports device type ETHERNET. The
+    // connection type has to be checked first or such a VPN classifies as Wired.
+    if matches!(connection_type, Some("vpn" | "wireguard")) {
+        return ActiveConnectionKind::Vpn;
+    }
+
     match raw_device_type {
         Some(raw_type) if device_type_registry::is_wired(raw_type) => ActiveConnectionKind::Wired,
         Some(device_type::WIFI) => ActiveConnectionKind::Wifi,
-        _ if matches!(connection_type, Some("vpn" | "wireguard")) => ActiveConnectionKind::Vpn,
         _ => ActiveConnectionKind::Other,
     }
 }
@@ -381,9 +387,25 @@ mod tests {
     use std::collections::HashMap;
 
     #[test]
-    fn classifies_by_device_type_first() {
+    fn classifies_vpn_carried_over_a_physical_device_as_vpn() {
         assert_eq!(
             active_connection_kind(Some(device_type::ETHERNET), Some("vpn")),
+            ActiveConnectionKind::Vpn
+        );
+        assert_eq!(
+            active_connection_kind(Some(device_type::WIFI), Some("vpn")),
+            ActiveConnectionKind::Vpn
+        );
+        assert_eq!(
+            active_connection_kind(Some(device_type::ETHERNET), Some("wireguard")),
+            ActiveConnectionKind::Vpn
+        );
+    }
+
+    #[test]
+    fn classifies_non_vpn_connections_by_device_type() {
+        assert_eq!(
+            active_connection_kind(Some(device_type::ETHERNET), Some("802-3-ethernet")),
             ActiveConnectionKind::Wired
         );
         assert_eq!(
@@ -391,7 +413,7 @@ mod tests {
             ActiveConnectionKind::Wired
         );
         assert_eq!(
-            active_connection_kind(Some(device_type::WIFI), Some("vpn")),
+            active_connection_kind(Some(device_type::WIFI), Some("802-11-wireless")),
             ActiveConnectionKind::Wifi
         );
     }


### PR DESCRIPTION
An active VPN that NetworkManager parents on the physical device it tunnels over (e.g. OpenVPN on `enp42s0`) was classified as `ActiveConnection::Wired` because `active_connection_kind` matched the device type first, hiding it from consumers that filter on the `Vpn` variant

This PR fixes it such that we check the `vpn`/`wireguard` connection type up front and only then fall back to device type.

Fixes https://github.com/pop-os/cosmic-settings/issues/2112